### PR TITLE
Update to obscure secret variables from console log.

### DIFF
--- a/Common/Node/expandJObject.ts
+++ b/Common/Node/expandJObject.ts
@@ -1,16 +1,16 @@
 import tl = require('vsts-task-lib/task');
 export function recursiveProcessing(obj: any, prefix: string, isSecret: boolean): void {
+    var typeArray: string[] =["string", "number", "boolean"];
     if (obj instanceof Array) {
         for (var index = 0; index < obj.length; index++) {
             var element = obj[index];
             recursiveProcessing(element, prefix + "_" + index.toString(), isSecret);
         }
-    } else if (typeof obj === "string") {
-        console.log("Injecting variable : " + prefix + ", value : " + obj);
-        tl.setVariable(prefix, obj, isSecret);
-    } else if (typeof obj === "number" || typeof obj === "boolean") {
-        console.log("Injecting variable : " + prefix + ", value : " + obj.toString());
-        tl.setVariable(prefix, obj.toString(), isSecret);
+    } else if (typeArray.indexOf(typeof obj) > -1) {
+        var objValue = typeArray.indexOf(typeof obj)>0 ? obj.toString() : obj;
+        var objDisplayValue = isSecret ? "******" : objValue;
+        console.log("Injecting variable : " + prefix + ", value : " + objDisplayValue);
+        tl.setVariable(prefix, objValue, isSecret);
     } else {
         for (var key in obj) {
             if (obj.hasOwnProperty(key)) {


### PR DESCRIPTION
I missed this in my last PR. The variables are being set as secret but the extension itself logs out the raw values. I updated the method to reduce some of the checks that were necessary in order to use the obfuscation text "******". Let me know if you have concerns about the refactor.