### PR TITLE
suppress npm demand

### DIFF
--- a/Tasks/LoadJsonVariables/task.json
+++ b/Tasks/LoadJsonVariables/task.json
@@ -15,9 +15,6 @@
         "Minor": 0,
         "Patch": 0
     },
-    "demands": [
-        "npm"
-    ],
     "minimumAgentVersion": "1.91.0",
     "instanceNameFormat": "Load variables from $(JsonSource) with prefix : $(VariablePrefix)",
     "inputs": [

--- a/Tasks/LoadPlistVariables/task.json
+++ b/Tasks/LoadPlistVariables/task.json
@@ -15,9 +15,6 @@
         "Minor": 0,
         "Patch": 51
     },
-    "demands": [
-        "npm"
-    ],
     "minimumAgentVersion": "1.91.0",
     "instanceNameFormat": "Load variables from $(PlistSource) with prefix : $(VariablePrefix)",
     "inputs": [

--- a/Tasks/LoadXmlVariables/task.json
+++ b/Tasks/LoadXmlVariables/task.json
@@ -15,9 +15,6 @@
         "Minor": 0,
         "Patch": 51
     },
-    "demands": [
-        "npm"
-    ],
     "minimumAgentVersion": "1.91.0",
     "instanceNameFormat": "Load variables from $(XmlSource) with prefix : $(VariablePrefix)",
     "inputs": [

--- a/Tasks/LoadYamlVariables/task.json
+++ b/Tasks/LoadYamlVariables/task.json
@@ -15,9 +15,6 @@
         "Minor": 0,
         "Patch": 51
     },
-    "demands": [
-        "npm"
-    ],
     "minimumAgentVersion": "1.91.0",
     "instanceNameFormat": "Load variables from $(YamlSource) with prefix : $(VariablePrefix)",
     "inputs": [


### PR DESCRIPTION
The 'npm' demand can be deleted.
All tasks run successfully without 'npm' installed on the host.
You can see below a pipeline running on a host without npm installed below.
https://dev.azure.com/agiletour/LoadVariables/_build/results?buildId=239&view=results

The host is based on the default image "Azure Windows 2019" with nothing but the Azure Pipelines Agent installed on it.
This change will allow us to use these tasks on a host without npm installed (or to avoid adding a false capacity on the agent)