### PR TITLE
Upgrade node version

### DIFF
--- a/Common/Node/expandJObject.ts
+++ b/Common/Node/expandJObject.ts
@@ -1,4 +1,4 @@
-import tl = require("azure-pipelines-task-lib");
+import * as tl from "azure-pipelines-task-lib";
 
 export function recursiveProcessing(obj: any, prefix: string, isSecret: boolean): void {
     let typeArray: string[] = ["string", "number", "boolean"];

--- a/Tasks/LoadJsonVariables/package-lock.json
+++ b/Tasks/LoadJsonVariables/package-lock.json
@@ -1,478 +1,455 @@
 {
   "name": "loadjsonvariables",
   "version": "0.1.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@types/concat-stream": {
-      "version": "1.6.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/concat-stream/-/concat-stream-1.6.1.tgz",
-      "integrity": "sha1-JLz8EB7PaOiGqu3OYN/XS2MqG3Q=",
-      "requires": {
-        "@types/node": "*"
+  "packages": {
+    "": {
+      "name": "loadjsonvariables",
+      "version": "0.1.0",
+      "dependencies": {
+        "azure-pipelines-task-lib": "^4.13.0",
+        "fs-extra": "^10.0.0"
       }
     },
-    "@types/form-data": {
-      "version": "0.0.33",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/form-data/-/form-data-0.0.33.tgz",
-      "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
-      "requires": {
-        "@types/node": "*"
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
-    "@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha1-NfPWIT2u2V2n8Pc+dbzGmA6QWXs="
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
-    "@types/qs": {
-      "version": "6.9.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha1-Y7t9Bn2xB8weRXwwO8JdUR/r9ss="
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "azure-pipelines-task-lib": {
-      "version": "3.1.10",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.1.10.tgz",
-      "integrity": "sha1-NLoir8okcv06I2bd9XTBzxH7L2Y=",
-      "requires": {
-        "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
+    "node_modules/azure-pipelines-task-lib": {
+      "version": "4.17.3",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
+      "integrity": "sha512-UxfH5pk3uOHTi9TtLtdDyugQVkFES5A836ZEePjcs3jYyxm3EJ6IlFYq6gbfd6mNBhrM9fxG2u/MFYIJ+Z0cxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "adm-zip": "^0.5.10",
+        "minimatch": "3.0.5",
+        "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
-        "semver": "^5.1.0",
-        "shelljs": "^0.8.4",
-        "sync-request": "6.1.0",
+        "semver": "^5.7.2",
+        "shelljs": "^0.8.5",
         "uuid": "^3.0.1"
       }
     },
-    "balanced-match": {
+    "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4="
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
     },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
-      "requires": {
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U="
-    },
-    "call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=",
-      "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
-      }
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
-    "concat-map": {
+    "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
     },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
-    "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U="
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "form-data": {
-      "version": "2.5.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha1-8svsV7XlniNxbhKP5E1OXdI4lfQ=",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
-    "fs-extra": {
+    "node_modules/fs-extra": {
       "version": "10.0.0",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/fs-extra/-/fs-extra-10.0.0.tgz",
       "integrity": "sha1-n/YbZV3eU/s0qC34S7IUzoAuF8E=",
-      "requires": {
+      "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
-    "fs.realpath": {
+    "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
     },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
-    },
-    "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha1-FfWfN2+FXERpY5SPDSTNNje0q8Y=",
-      "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "get-port": {
-      "version": "3.2.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/get-port/-/get-port-3.2.0.tgz",
-      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
-    },
-    "glob": {
-      "version": "7.2.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha1-0VU1r3cy4C6Uj0xBYovZECk/YCM=",
-      "requires": {
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "graceful-fs": {
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/graceful-fs": {
       "version": "4.2.8",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/graceful-fs/-/graceful-fs-4.2.8.tgz",
       "integrity": "sha1-5BK40z9eAGWTy9PO5t+fLOu+gCo="
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/has/-/has-1.0.3.tgz",
-      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
-      "requires": {
-        "function-bind": "^1.1.1"
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha1-Fl0wcMADCXUqEjakeTMeOsVvFCM="
-    },
-    "http-basic": {
-      "version": "8.1.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/http-basic/-/http-basic-8.1.3.tgz",
-      "integrity": "sha1-p8q+51Joabm3EBNpcIBbEAQmG78=",
-      "requires": {
-        "caseless": "^0.12.0",
-        "concat-stream": "^1.6.2",
-        "http-response-object": "^3.0.1",
-        "parse-cache-control": "^1.0.1"
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
-    "http-response-object": {
-      "version": "3.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/http-response-object/-/http-response-object-3.0.2.tgz",
-      "integrity": "sha1-f0NbshBFTkNg0HTvH5idXqiqmBA=",
-      "requires": {
-        "@types/node": "^10.0.3"
-      }
-    },
-    "inflight": {
+    "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
-    "interpret": {
+    "node_modules/interpret": {
       "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4="
-    },
-    "is-core-module": {
-      "version": "2.8.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-core-module/-/is-core-module-2.8.0.tgz",
-      "integrity": "sha1-AyEzbD0JJeSX/Zf12VyxFKXM1Ug=",
-      "requires": {
-        "has": "^1.0.3"
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "jsonfile": {
+    "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha1-vFWyY0eTxnnsZAMJTrE2mKbsCq4=",
-      "requires": {
-        "graceful-fs": "^4.1.6",
+      "dependencies": {
         "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
-    "mime-db": {
-      "version": "1.51.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha1-2f9iRRhZsYNC2WCFDcPPt35j+ww="
-    },
-    "mime-types": {
-      "version": "2.1.34",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/mime-types/-/mime-types-2.1.34.tgz",
-      "integrity": "sha1-WnEvnsFQNRGpRYA2QPr+CdN5PCQ=",
-      "requires": {
-        "mime-db": "1.51.0"
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-      "requires": {
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+      "license": "ISC",
+      "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "mockery": {
-      "version": "1.7.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/mockery/-/mockery-1.7.0.tgz",
-      "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
-    "object-inspect": {
-      "version": "1.11.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha1-nc6xRs7dQUig2eUauI00z1CZIrE="
+    "node_modules/nodejs-file-downloader": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz",
+      "integrity": "sha512-nI2fKnmJWWFZF6SgMPe1iBodKhfpztLKJTtCtNYGhm/9QXmWa/Pk9Sv00qHgzEvNLe1x7hjGDRor7gcm/ChaIQ==",
+      "license": "ISC",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "https-proxy-agent": "^5.0.0",
+        "mime-types": "^2.1.27",
+        "sanitize-filename": "^1.6.3"
+      }
     },
-    "once": {
+    "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
         "wrappy": "1"
       }
     },
-    "parse-cache-control": {
+    "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
-      "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104="
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-    },
-    "path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU="
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
-    },
-    "promise": {
-      "version": "8.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/promise/-/promise-8.1.0.tgz",
-      "integrity": "sha1-aXwlw9/nQ13Xn81Yw4oTWIjq8F4=",
-      "requires": {
-        "asap": "~2.0.6"
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "q": {
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
-    },
-    "qs": {
-      "version": "6.10.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/qs/-/qs-6.10.1.tgz",
-      "integrity": "sha1-STFIL6jWR6Wqt5nFJx0hM7mB+2o=",
-      "requires": {
-        "side-channel": "^1.0.4"
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
       }
     },
-    "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "rechoir": {
+    "node_modules/rechoir": {
       "version": "0.6.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "requires": {
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dependencies": {
         "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
-    "resolve": {
-      "version": "1.20.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha1-YpoBP7P3B1XW8LeTXMHCxTeLGXU=",
-      "requires": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+    "node_modules/sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "license": "WTFPL OR ISC",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
     },
-    "semver": {
-      "version": "5.7.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
+    "node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
     },
-    "shelljs": {
-      "version": "0.8.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/shelljs/-/shelljs-0.8.4.tgz",
-      "integrity": "sha1-3naE/ut2f4cWsyYHiooAh1iQ48I=",
-      "requires": {
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
         "rechoir": "^0.6.2"
-      }
-    },
-    "side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha1-785cj9wQTudRslxY1CkAEfpeos8=",
-      "requires": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "sync-request": {
-      "version": "6.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/sync-request/-/sync-request-6.1.0.tgz",
-      "integrity": "sha1-6WIXVlteULv/4XmGi6dVMvtZfmg=",
-      "requires": {
-        "http-response-object": "^3.0.1",
-        "sync-rpc": "^1.2.1",
-        "then-request": "^6.0.0"
-      }
-    },
-    "sync-rpc": {
-      "version": "1.3.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/sync-rpc/-/sync-rpc-1.3.6.tgz",
-      "integrity": "sha1-suiyVQoSzLxx34ZEgQUp3raGZac=",
-      "requires": {
-        "get-port": "^3.1.0"
-      }
-    },
-    "then-request": {
-      "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/then-request/-/then-request-6.0.2.tgz",
-      "integrity": "sha1-7Bjdi1ykOq7ly5L35MFjDpUNTww=",
-      "requires": {
-        "@types/concat-stream": "^1.6.0",
-        "@types/form-data": "0.0.33",
-        "@types/node": "^8.0.0",
-        "@types/qs": "^6.2.31",
-        "caseless": "~0.12.0",
-        "concat-stream": "^1.6.0",
-        "form-data": "^2.2.0",
-        "http-basic": "^8.1.1",
-        "http-response-object": "^3.0.1",
-        "promise": "^8.0.0",
-        "qs": "^6.4.0"
       },
-      "dependencies": {
-        "@types/node": {
-          "version": "8.10.66",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/node/-/node-8.10.66.tgz",
-          "integrity": "sha1-3QNdQJ3zIqzIPf9ipgLxKleDu7M="
-        }
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "universalify": {
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "license": "WTFPL",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "node_modules/universalify": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha1-daSYTv7cSwiXXFrrc/Uw0C3yVxc="
+      "integrity": "sha1-daSYTv7cSwiXXFrrc/Uw0C3yVxc=",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+      "license": "(WTFPL OR MIT)"
     },
-    "uuid": {
+    "node_modules/uuid": {
       "version": "3.4.0",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
+      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
     },
-    "wrappy": {
+    "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     }
   }
 }

--- a/Tasks/LoadJsonVariables/package.json
+++ b/Tasks/LoadJsonVariables/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "dependencies": {
-    "azure-pipelines-task-lib": "^3.1.10",
+    "azure-pipelines-task-lib": "^4.13.0",
     "fs-extra": "^10.0.0"
   }
 }

--- a/Tasks/LoadJsonVariables/task.json
+++ b/Tasks/LoadJsonVariables/task.json
@@ -18,7 +18,7 @@
     "demands": [
         "npm"
     ],
-    "minimumAgentVersion": "1.91.0",
+    "minimumAgentVersion": "2.144.0",
     "instanceNameFormat": "Load variables from $(JsonSource) with prefix : $(VariablePrefix)",
     "inputs": [
         {
@@ -48,6 +48,10 @@
     ],
     "execution": {
         "Node10": {
+            "target": "loadjsonvariables.js",
+            "argumentFormat": ""
+        },
+        "Node20_1": {
             "target": "loadjsonvariables.js",
             "argumentFormat": ""
         }

--- a/Tasks/LoadPlistVariables/package-lock.json
+++ b/Tasks/LoadPlistVariables/package-lock.json
@@ -1,497 +1,495 @@
 {
   "name": "loadplistvariables",
   "version": "0.1.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@types/concat-stream": {
-      "version": "1.6.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/concat-stream/-/concat-stream-1.6.1.tgz",
-      "integrity": "sha1-JLz8EB7PaOiGqu3OYN/XS2MqG3Q=",
-      "requires": {
-        "@types/node": "*"
+  "packages": {
+    "": {
+      "name": "loadplistvariables",
+      "version": "0.1.0",
+      "dependencies": {
+        "azure-pipelines-task-lib": "^4.13.0",
+        "fs-extra": "^10.0.0",
+        "plist": "^3.0.4"
       }
     },
-    "@types/form-data": {
-      "version": "0.0.33",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/form-data/-/form-data-0.0.33.tgz",
-      "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
-      "requires": {
-        "@types/node": "*"
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
-    "@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha1-NfPWIT2u2V2n8Pc+dbzGmA6QWXs="
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
-    "@types/qs": {
-      "version": "6.9.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha1-Y7t9Bn2xB8weRXwwO8JdUR/r9ss="
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "azure-pipelines-task-lib": {
-      "version": "3.1.10",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.1.10.tgz",
-      "integrity": "sha1-NLoir8okcv06I2bd9XTBzxH7L2Y=",
-      "requires": {
-        "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
+    "node_modules/azure-pipelines-task-lib": {
+      "version": "4.17.3",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
+      "integrity": "sha512-UxfH5pk3uOHTi9TtLtdDyugQVkFES5A836ZEePjcs3jYyxm3EJ6IlFYq6gbfd6mNBhrM9fxG2u/MFYIJ+Z0cxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "adm-zip": "^0.5.10",
+        "minimatch": "3.0.5",
+        "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
-        "semver": "^5.1.0",
-        "shelljs": "^0.8.4",
-        "sync-request": "6.1.0",
+        "semver": "^5.7.2",
+        "shelljs": "^0.8.5",
         "uuid": "^3.0.1"
       }
     },
-    "balanced-match": {
+    "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4="
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
     },
-    "base64-js": {
+    "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo="
+      "integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo=",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
-      "requires": {
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U="
-    },
-    "call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=",
-      "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
-      }
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
-    "concat-map": {
+    "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
     },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
-    "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U="
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "form-data": {
-      "version": "2.5.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha1-8svsV7XlniNxbhKP5E1OXdI4lfQ=",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
-    "fs-extra": {
+    "node_modules/fs-extra": {
       "version": "10.0.0",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/fs-extra/-/fs-extra-10.0.0.tgz",
       "integrity": "sha1-n/YbZV3eU/s0qC34S7IUzoAuF8E=",
-      "requires": {
+      "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
-    "fs.realpath": {
+    "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
     },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
-    },
-    "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha1-FfWfN2+FXERpY5SPDSTNNje0q8Y=",
-      "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "get-port": {
-      "version": "3.2.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/get-port/-/get-port-3.2.0.tgz",
-      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
-    },
-    "glob": {
-      "version": "7.2.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha1-0VU1r3cy4C6Uj0xBYovZECk/YCM=",
-      "requires": {
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "graceful-fs": {
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/graceful-fs": {
       "version": "4.2.8",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/graceful-fs/-/graceful-fs-4.2.8.tgz",
       "integrity": "sha1-5BK40z9eAGWTy9PO5t+fLOu+gCo="
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/has/-/has-1.0.3.tgz",
-      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
-      "requires": {
-        "function-bind": "^1.1.1"
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha1-Fl0wcMADCXUqEjakeTMeOsVvFCM="
-    },
-    "http-basic": {
-      "version": "8.1.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/http-basic/-/http-basic-8.1.3.tgz",
-      "integrity": "sha1-p8q+51Joabm3EBNpcIBbEAQmG78=",
-      "requires": {
-        "caseless": "^0.12.0",
-        "concat-stream": "^1.6.2",
-        "http-response-object": "^3.0.1",
-        "parse-cache-control": "^1.0.1"
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
-    "http-response-object": {
-      "version": "3.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/http-response-object/-/http-response-object-3.0.2.tgz",
-      "integrity": "sha1-f0NbshBFTkNg0HTvH5idXqiqmBA=",
-      "requires": {
-        "@types/node": "^10.0.3"
-      }
-    },
-    "inflight": {
+    "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
-    "interpret": {
+    "node_modules/interpret": {
       "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4="
-    },
-    "is-core-module": {
-      "version": "2.8.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-core-module/-/is-core-module-2.8.0.tgz",
-      "integrity": "sha1-AyEzbD0JJeSX/Zf12VyxFKXM1Ug=",
-      "requires": {
-        "has": "^1.0.3"
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "jsonfile": {
+    "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha1-vFWyY0eTxnnsZAMJTrE2mKbsCq4=",
-      "requires": {
-        "graceful-fs": "^4.1.6",
+      "dependencies": {
         "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
-    "mime-db": {
-      "version": "1.51.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha1-2f9iRRhZsYNC2WCFDcPPt35j+ww="
-    },
-    "mime-types": {
-      "version": "2.1.34",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/mime-types/-/mime-types-2.1.34.tgz",
-      "integrity": "sha1-WnEvnsFQNRGpRYA2QPr+CdN5PCQ=",
-      "requires": {
-        "mime-db": "1.51.0"
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-      "requires": {
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+      "license": "ISC",
+      "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "mockery": {
-      "version": "1.7.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/mockery/-/mockery-1.7.0.tgz",
-      "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
-    "object-inspect": {
-      "version": "1.11.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha1-nc6xRs7dQUig2eUauI00z1CZIrE="
+    "node_modules/nodejs-file-downloader": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz",
+      "integrity": "sha512-nI2fKnmJWWFZF6SgMPe1iBodKhfpztLKJTtCtNYGhm/9QXmWa/Pk9Sv00qHgzEvNLe1x7hjGDRor7gcm/ChaIQ==",
+      "license": "ISC",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "https-proxy-agent": "^5.0.0",
+        "mime-types": "^2.1.27",
+        "sanitize-filename": "^1.6.3"
+      }
     },
-    "once": {
+    "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
         "wrappy": "1"
       }
     },
-    "parse-cache-control": {
+    "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
-      "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104="
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-    },
-    "path-parse": {
+    "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU="
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
     },
-    "plist": {
+    "node_modules/plist": {
       "version": "3.0.4",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/plist/-/plist-3.0.4.tgz",
       "integrity": "sha1-pi34N+Ou0rs7c1iZ1RDE8YYBnL4=",
-      "requires": {
+      "dependencies": {
         "base64-js": "^1.5.1",
         "xmlbuilder": "^9.0.7"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
-    },
-    "promise": {
-      "version": "8.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/promise/-/promise-8.1.0.tgz",
-      "integrity": "sha1-aXwlw9/nQ13Xn81Yw4oTWIjq8F4=",
-      "requires": {
-        "asap": "~2.0.6"
-      }
-    },
-    "q": {
+    "node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
-    },
-    "qs": {
-      "version": "6.10.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/qs/-/qs-6.10.1.tgz",
-      "integrity": "sha1-STFIL6jWR6Wqt5nFJx0hM7mB+2o=",
-      "requires": {
-        "side-channel": "^1.0.4"
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
       }
     },
-    "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "rechoir": {
+    "node_modules/rechoir": {
       "version": "0.6.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "requires": {
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dependencies": {
         "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
-    "resolve": {
-      "version": "1.20.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha1-YpoBP7P3B1XW8LeTXMHCxTeLGXU=",
-      "requires": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+    "node_modules/sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "license": "WTFPL OR ISC",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
     },
-    "semver": {
-      "version": "5.7.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
+    "node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
     },
-    "shelljs": {
-      "version": "0.8.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/shelljs/-/shelljs-0.8.4.tgz",
-      "integrity": "sha1-3naE/ut2f4cWsyYHiooAh1iQ48I=",
-      "requires": {
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
         "rechoir": "^0.6.2"
-      }
-    },
-    "side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha1-785cj9wQTudRslxY1CkAEfpeos8=",
-      "requires": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "sync-request": {
-      "version": "6.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/sync-request/-/sync-request-6.1.0.tgz",
-      "integrity": "sha1-6WIXVlteULv/4XmGi6dVMvtZfmg=",
-      "requires": {
-        "http-response-object": "^3.0.1",
-        "sync-rpc": "^1.2.1",
-        "then-request": "^6.0.0"
-      }
-    },
-    "sync-rpc": {
-      "version": "1.3.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/sync-rpc/-/sync-rpc-1.3.6.tgz",
-      "integrity": "sha1-suiyVQoSzLxx34ZEgQUp3raGZac=",
-      "requires": {
-        "get-port": "^3.1.0"
-      }
-    },
-    "then-request": {
-      "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/then-request/-/then-request-6.0.2.tgz",
-      "integrity": "sha1-7Bjdi1ykOq7ly5L35MFjDpUNTww=",
-      "requires": {
-        "@types/concat-stream": "^1.6.0",
-        "@types/form-data": "0.0.33",
-        "@types/node": "^8.0.0",
-        "@types/qs": "^6.2.31",
-        "caseless": "~0.12.0",
-        "concat-stream": "^1.6.0",
-        "form-data": "^2.2.0",
-        "http-basic": "^8.1.1",
-        "http-response-object": "^3.0.1",
-        "promise": "^8.0.0",
-        "qs": "^6.4.0"
       },
-      "dependencies": {
-        "@types/node": {
-          "version": "8.10.66",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/node/-/node-8.10.66.tgz",
-          "integrity": "sha1-3QNdQJ3zIqzIPf9ipgLxKleDu7M="
-        }
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "universalify": {
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "license": "WTFPL",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "node_modules/universalify": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha1-daSYTv7cSwiXXFrrc/Uw0C3yVxc="
+      "integrity": "sha1-daSYTv7cSwiXXFrrc/Uw0C3yVxc=",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+      "license": "(WTFPL OR MIT)"
     },
-    "uuid": {
+    "node_modules/uuid": {
       "version": "3.4.0",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
+      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
     },
-    "wrappy": {
+    "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
-    "xmlbuilder": {
+    "node_modules/xmlbuilder": {
       "version": "9.0.7",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+      "engines": {
+        "node": ">=4.0"
+      }
     }
   }
 }

--- a/Tasks/LoadPlistVariables/package.json
+++ b/Tasks/LoadPlistVariables/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "dependencies": {
-    "azure-pipelines-task-lib": "^3.1.10",
+    "azure-pipelines-task-lib": "^4.13.0",
     "fs-extra": "^10.0.0",
     "plist": "^3.0.4"
   }

--- a/Tasks/LoadPlistVariables/task.json
+++ b/Tasks/LoadPlistVariables/task.json
@@ -18,7 +18,7 @@
     "demands": [
         "npm"
     ],
-    "minimumAgentVersion": "1.91.0",
+    "minimumAgentVersion": "2.144.0",
     "instanceNameFormat": "Load variables from $(PlistSource) with prefix : $(VariablePrefix)",
     "inputs": [
         {
@@ -48,6 +48,10 @@
     ],
     "execution": {
         "Node10": {
+            "target": "loadplistvariables.js",
+            "argumentFormat": ""
+        },
+        "Node20_1": {
             "target": "loadplistvariables.js",
             "argumentFormat": ""
         }

--- a/Tasks/LoadXmlVariables/package-lock.json
+++ b/Tasks/LoadXmlVariables/package-lock.json
@@ -1,491 +1,473 @@
 {
   "name": "loadxmlvariables",
   "version": "0.1.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@types/concat-stream": {
-      "version": "1.6.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/concat-stream/-/concat-stream-1.6.1.tgz",
-      "integrity": "sha1-JLz8EB7PaOiGqu3OYN/XS2MqG3Q=",
-      "requires": {
-        "@types/node": "*"
+  "packages": {
+    "": {
+      "name": "loadxmlvariables",
+      "version": "0.1.0",
+      "dependencies": {
+        "azure-pipelines-task-lib": "^4.13.0",
+        "fs-extra": "^10.0.0",
+        "jxon": "2.0.0-beta.3"
       }
     },
-    "@types/form-data": {
-      "version": "0.0.33",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/form-data/-/form-data-0.0.33.tgz",
-      "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
-      "requires": {
-        "@types/node": "*"
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
-    "@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha1-NfPWIT2u2V2n8Pc+dbzGmA6QWXs="
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
-    "@types/qs": {
-      "version": "6.9.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha1-Y7t9Bn2xB8weRXwwO8JdUR/r9ss="
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "azure-pipelines-task-lib": {
-      "version": "3.1.10",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.1.10.tgz",
-      "integrity": "sha1-NLoir8okcv06I2bd9XTBzxH7L2Y=",
-      "requires": {
-        "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
+    "node_modules/azure-pipelines-task-lib": {
+      "version": "4.17.3",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
+      "integrity": "sha512-UxfH5pk3uOHTi9TtLtdDyugQVkFES5A836ZEePjcs3jYyxm3EJ6IlFYq6gbfd6mNBhrM9fxG2u/MFYIJ+Z0cxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "adm-zip": "^0.5.10",
+        "minimatch": "3.0.5",
+        "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
-        "semver": "^5.1.0",
-        "shelljs": "^0.8.4",
-        "sync-request": "6.1.0",
+        "semver": "^5.7.2",
+        "shelljs": "^0.8.5",
         "uuid": "^3.0.1"
       }
     },
-    "balanced-match": {
+    "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4="
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
     },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
-      "requires": {
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U="
-    },
-    "call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=",
-      "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
-      }
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
-    "concat-map": {
+    "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
     },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
-    "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U="
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "form-data": {
-      "version": "2.5.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha1-8svsV7XlniNxbhKP5E1OXdI4lfQ=",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
-    "fs-extra": {
+    "node_modules/fs-extra": {
       "version": "10.0.0",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/fs-extra/-/fs-extra-10.0.0.tgz",
       "integrity": "sha1-n/YbZV3eU/s0qC34S7IUzoAuF8E=",
-      "requires": {
+      "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
-    "fs.realpath": {
+    "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
     },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
-    },
-    "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha1-FfWfN2+FXERpY5SPDSTNNje0q8Y=",
-      "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "get-port": {
-      "version": "3.2.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/get-port/-/get-port-3.2.0.tgz",
-      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
-    },
-    "glob": {
-      "version": "7.2.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha1-0VU1r3cy4C6Uj0xBYovZECk/YCM=",
-      "requires": {
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "graceful-fs": {
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/graceful-fs": {
       "version": "4.2.8",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/graceful-fs/-/graceful-fs-4.2.8.tgz",
       "integrity": "sha1-5BK40z9eAGWTy9PO5t+fLOu+gCo="
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/has/-/has-1.0.3.tgz",
-      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
-      "requires": {
-        "function-bind": "^1.1.1"
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha1-Fl0wcMADCXUqEjakeTMeOsVvFCM="
-    },
-    "http-basic": {
-      "version": "8.1.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/http-basic/-/http-basic-8.1.3.tgz",
-      "integrity": "sha1-p8q+51Joabm3EBNpcIBbEAQmG78=",
-      "requires": {
-        "caseless": "^0.12.0",
-        "concat-stream": "^1.6.2",
-        "http-response-object": "^3.0.1",
-        "parse-cache-control": "^1.0.1"
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
-    "http-response-object": {
-      "version": "3.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/http-response-object/-/http-response-object-3.0.2.tgz",
-      "integrity": "sha1-f0NbshBFTkNg0HTvH5idXqiqmBA=",
-      "requires": {
-        "@types/node": "^10.0.3"
-      }
-    },
-    "inflight": {
+    "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
-    "interpret": {
+    "node_modules/interpret": {
       "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4="
-    },
-    "is-core-module": {
-      "version": "2.8.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-core-module/-/is-core-module-2.8.0.tgz",
-      "integrity": "sha1-AyEzbD0JJeSX/Zf12VyxFKXM1Ug=",
-      "requires": {
-        "has": "^1.0.3"
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "jsonfile": {
+    "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha1-vFWyY0eTxnnsZAMJTrE2mKbsCq4=",
-      "requires": {
-        "graceful-fs": "^4.1.6",
+      "dependencies": {
         "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
-    "jxon": {
+    "node_modules/jxon": {
       "version": "2.0.0-beta.3",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/jxon/-/jxon-2.0.0-beta.3.tgz",
       "integrity": "sha1-1w+YCOjpb9XFY3OHXbQW6pPaGqM=",
-      "requires": {
+      "dependencies": {
         "xmldom": "^0.1.21"
       }
     },
-    "mime-db": {
-      "version": "1.51.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha1-2f9iRRhZsYNC2WCFDcPPt35j+ww="
-    },
-    "mime-types": {
-      "version": "2.1.34",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/mime-types/-/mime-types-2.1.34.tgz",
-      "integrity": "sha1-WnEvnsFQNRGpRYA2QPr+CdN5PCQ=",
-      "requires": {
-        "mime-db": "1.51.0"
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-      "requires": {
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+      "license": "ISC",
+      "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "mockery": {
-      "version": "1.7.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/mockery/-/mockery-1.7.0.tgz",
-      "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
-    "object-inspect": {
-      "version": "1.11.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha1-nc6xRs7dQUig2eUauI00z1CZIrE="
+    "node_modules/nodejs-file-downloader": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz",
+      "integrity": "sha512-nI2fKnmJWWFZF6SgMPe1iBodKhfpztLKJTtCtNYGhm/9QXmWa/Pk9Sv00qHgzEvNLe1x7hjGDRor7gcm/ChaIQ==",
+      "license": "ISC",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "https-proxy-agent": "^5.0.0",
+        "mime-types": "^2.1.27",
+        "sanitize-filename": "^1.6.3"
+      }
     },
-    "once": {
+    "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
         "wrappy": "1"
       }
     },
-    "parse-cache-control": {
+    "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
-      "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104="
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-    },
-    "path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU="
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
-    },
-    "promise": {
-      "version": "8.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/promise/-/promise-8.1.0.tgz",
-      "integrity": "sha1-aXwlw9/nQ13Xn81Yw4oTWIjq8F4=",
-      "requires": {
-        "asap": "~2.0.6"
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "q": {
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
-    },
-    "qs": {
-      "version": "6.10.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/qs/-/qs-6.10.1.tgz",
-      "integrity": "sha1-STFIL6jWR6Wqt5nFJx0hM7mB+2o=",
-      "requires": {
-        "side-channel": "^1.0.4"
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
       }
     },
-    "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "rechoir": {
+    "node_modules/rechoir": {
       "version": "0.6.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "requires": {
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dependencies": {
         "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
-    "resolve": {
-      "version": "1.20.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha1-YpoBP7P3B1XW8LeTXMHCxTeLGXU=",
-      "requires": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+    "node_modules/sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "license": "WTFPL OR ISC",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
     },
-    "semver": {
-      "version": "5.7.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
+    "node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
     },
-    "shelljs": {
-      "version": "0.8.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/shelljs/-/shelljs-0.8.4.tgz",
-      "integrity": "sha1-3naE/ut2f4cWsyYHiooAh1iQ48I=",
-      "requires": {
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
         "rechoir": "^0.6.2"
-      }
-    },
-    "side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha1-785cj9wQTudRslxY1CkAEfpeos8=",
-      "requires": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "sync-request": {
-      "version": "6.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/sync-request/-/sync-request-6.1.0.tgz",
-      "integrity": "sha1-6WIXVlteULv/4XmGi6dVMvtZfmg=",
-      "requires": {
-        "http-response-object": "^3.0.1",
-        "sync-rpc": "^1.2.1",
-        "then-request": "^6.0.0"
-      }
-    },
-    "sync-rpc": {
-      "version": "1.3.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/sync-rpc/-/sync-rpc-1.3.6.tgz",
-      "integrity": "sha1-suiyVQoSzLxx34ZEgQUp3raGZac=",
-      "requires": {
-        "get-port": "^3.1.0"
-      }
-    },
-    "then-request": {
-      "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/then-request/-/then-request-6.0.2.tgz",
-      "integrity": "sha1-7Bjdi1ykOq7ly5L35MFjDpUNTww=",
-      "requires": {
-        "@types/concat-stream": "^1.6.0",
-        "@types/form-data": "0.0.33",
-        "@types/node": "^8.0.0",
-        "@types/qs": "^6.2.31",
-        "caseless": "~0.12.0",
-        "concat-stream": "^1.6.0",
-        "form-data": "^2.2.0",
-        "http-basic": "^8.1.1",
-        "http-response-object": "^3.0.1",
-        "promise": "^8.0.0",
-        "qs": "^6.4.0"
       },
-      "dependencies": {
-        "@types/node": {
-          "version": "8.10.66",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/node/-/node-8.10.66.tgz",
-          "integrity": "sha1-3QNdQJ3zIqzIPf9ipgLxKleDu7M="
-        }
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "universalify": {
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "license": "WTFPL",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "node_modules/universalify": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha1-daSYTv7cSwiXXFrrc/Uw0C3yVxc="
+      "integrity": "sha1-daSYTv7cSwiXXFrrc/Uw0C3yVxc=",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+      "license": "(WTFPL OR MIT)"
     },
-    "uuid": {
+    "node_modules/uuid": {
       "version": "3.4.0",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
+      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
     },
-    "wrappy": {
+    "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
-    "xmldom": {
+    "node_modules/xmldom": {
       "version": "0.1.31",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/xmldom/-/xmldom-0.1.31.tgz",
-      "integrity": "sha1-t2yaG9nwqXN+WnLcNyMc84N14v8="
+      "integrity": "sha1-t2yaG9nwqXN+WnLcNyMc84N14v8=",
+      "deprecated": "Deprecated due to CVE-2021-21366 resolved in 0.5.0",
+      "engines": {
+        "node": ">=0.1"
+      }
     }
   }
 }

--- a/Tasks/LoadXmlVariables/package.json
+++ b/Tasks/LoadXmlVariables/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "dependencies": {
-    "azure-pipelines-task-lib": "^3.1.10",
+    "azure-pipelines-task-lib": "^4.13.0",
     "fs-extra": "^10.0.0",
     "jxon": "2.0.0-beta.3"
   }

--- a/Tasks/LoadXmlVariables/task.json
+++ b/Tasks/LoadXmlVariables/task.json
@@ -18,7 +18,7 @@
     "demands": [
         "npm"
     ],
-    "minimumAgentVersion": "1.91.0",
+    "minimumAgentVersion": "2.144.0",
     "instanceNameFormat": "Load variables from $(XmlSource) with prefix : $(VariablePrefix)",
     "inputs": [
         {
@@ -48,6 +48,10 @@
     ],
     "execution": {
         "Node10": {
+            "target": "loadxmlvariables.js",
+            "argumentFormat": ""
+        },
+        "Node20_1": {
             "target": "loadxmlvariables.js",
             "argumentFormat": ""
         }

--- a/Tasks/LoadYamlVariables/package-lock.json
+++ b/Tasks/LoadYamlVariables/package-lock.json
@@ -1,491 +1,472 @@
 {
   "name": "loadyamlvariables",
   "version": "0.1.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@types/concat-stream": {
-      "version": "1.6.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/concat-stream/-/concat-stream-1.6.1.tgz",
-      "integrity": "sha1-JLz8EB7PaOiGqu3OYN/XS2MqG3Q=",
-      "requires": {
-        "@types/node": "*"
+  "packages": {
+    "": {
+      "name": "loadyamlvariables",
+      "version": "0.1.0",
+      "dependencies": {
+        "azure-pipelines-task-lib": "^4.13.0",
+        "fs-extra": "^10.0.0",
+        "js-yaml": "^4.1.0"
       }
     },
-    "@types/form-data": {
-      "version": "0.0.33",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/form-data/-/form-data-0.0.33.tgz",
-      "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
-      "requires": {
-        "@types/node": "*"
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
       }
     },
-    "@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha1-NfPWIT2u2V2n8Pc+dbzGmA6QWXs="
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
-    "@types/qs": {
-      "version": "6.9.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha1-Y7t9Bn2xB8weRXwwO8JdUR/r9ss="
-    },
-    "argparse": {
+    "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg="
     },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
-    },
-    "azure-pipelines-task-lib": {
-      "version": "3.1.10",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.1.10.tgz",
-      "integrity": "sha1-NLoir8okcv06I2bd9XTBzxH7L2Y=",
-      "requires": {
-        "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
+    "node_modules/azure-pipelines-task-lib": {
+      "version": "4.17.3",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
+      "integrity": "sha512-UxfH5pk3uOHTi9TtLtdDyugQVkFES5A836ZEePjcs3jYyxm3EJ6IlFYq6gbfd6mNBhrM9fxG2u/MFYIJ+Z0cxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "adm-zip": "^0.5.10",
+        "minimatch": "3.0.5",
+        "nodejs-file-downloader": "^4.11.1",
         "q": "^1.5.1",
-        "semver": "^5.1.0",
-        "shelljs": "^0.8.4",
-        "sync-request": "6.1.0",
+        "semver": "^5.7.2",
+        "shelljs": "^0.8.5",
         "uuid": "^3.0.1"
       }
     },
-    "balanced-match": {
+    "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4="
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
     },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
-      "requires": {
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
+      "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U="
-    },
-    "call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=",
-      "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
-      }
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
-    },
-    "concat-map": {
+    "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "license": "MIT"
     },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
-    "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U="
-    },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "form-data": {
-      "version": "2.5.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha1-8svsV7XlniNxbhKP5E1OXdI4lfQ=",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
-    "fs-extra": {
+    "node_modules/fs-extra": {
       "version": "10.0.0",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/fs-extra/-/fs-extra-10.0.0.tgz",
       "integrity": "sha1-n/YbZV3eU/s0qC34S7IUzoAuF8E=",
-      "requires": {
+      "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
-    "fs.realpath": {
+    "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "license": "ISC"
     },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
-    },
-    "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha1-FfWfN2+FXERpY5SPDSTNNje0q8Y=",
-      "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "get-port": {
-      "version": "3.2.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/get-port/-/get-port-3.2.0.tgz",
-      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
-    },
-    "glob": {
-      "version": "7.2.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha1-0VU1r3cy4C6Uj0xBYovZECk/YCM=",
-      "requires": {
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "license": "ISC",
+      "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
-        "minimatch": "^3.0.4",
+        "minimatch": "^3.1.1",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "graceful-fs": {
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/graceful-fs": {
       "version": "4.2.8",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/graceful-fs/-/graceful-fs-4.2.8.tgz",
       "integrity": "sha1-5BK40z9eAGWTy9PO5t+fLOu+gCo="
     },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/has/-/has-1.0.3.tgz",
-      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
-      "requires": {
-        "function-bind": "^1.1.1"
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "has-symbols": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha1-Fl0wcMADCXUqEjakeTMeOsVvFCM="
-    },
-    "http-basic": {
-      "version": "8.1.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/http-basic/-/http-basic-8.1.3.tgz",
-      "integrity": "sha1-p8q+51Joabm3EBNpcIBbEAQmG78=",
-      "requires": {
-        "caseless": "^0.12.0",
-        "concat-stream": "^1.6.2",
-        "http-response-object": "^3.0.1",
-        "parse-cache-control": "^1.0.1"
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
-    "http-response-object": {
-      "version": "3.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/http-response-object/-/http-response-object-3.0.2.tgz",
-      "integrity": "sha1-f0NbshBFTkNg0HTvH5idXqiqmBA=",
-      "requires": {
-        "@types/node": "^10.0.3"
-      }
-    },
-    "inflight": {
+    "node_modules/inflight": {
       "version": "1.0.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "requires": {
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "license": "ISC",
+      "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w="
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
-    "interpret": {
+    "node_modules/interpret": {
       "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4="
-    },
-    "is-core-module": {
-      "version": "2.8.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-core-module/-/is-core-module-2.8.0.tgz",
-      "integrity": "sha1-AyEzbD0JJeSX/Zf12VyxFKXM1Ug=",
-      "requires": {
-        "has": "^1.0.3"
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "js-yaml": {
+    "node_modules/js-yaml": {
       "version": "4.1.0",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha1-wftl+PUBeQHN0slRhkuhhFihBgI=",
-      "requires": {
+      "dependencies": {
         "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
-    "jsonfile": {
+    "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha1-vFWyY0eTxnnsZAMJTrE2mKbsCq4=",
-      "requires": {
-        "graceful-fs": "^4.1.6",
+      "dependencies": {
         "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
-    "mime-db": {
-      "version": "1.51.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha1-2f9iRRhZsYNC2WCFDcPPt35j+ww="
-    },
-    "mime-types": {
-      "version": "2.1.34",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/mime-types/-/mime-types-2.1.34.tgz",
-      "integrity": "sha1-WnEvnsFQNRGpRYA2QPr+CdN5PCQ=",
-      "requires": {
-        "mime-db": "1.51.0"
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-      "requires": {
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+      "license": "ISC",
+      "dependencies": {
         "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "mockery": {
-      "version": "1.7.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/mockery/-/mockery-1.7.0.tgz",
-      "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8="
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
-    "object-inspect": {
-      "version": "1.11.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha1-nc6xRs7dQUig2eUauI00z1CZIrE="
+    "node_modules/nodejs-file-downloader": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz",
+      "integrity": "sha512-nI2fKnmJWWFZF6SgMPe1iBodKhfpztLKJTtCtNYGhm/9QXmWa/Pk9Sv00qHgzEvNLe1x7hjGDRor7gcm/ChaIQ==",
+      "license": "ISC",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "https-proxy-agent": "^5.0.0",
+        "mime-types": "^2.1.27",
+        "sanitize-filename": "^1.6.3"
+      }
     },
-    "once": {
+    "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "requires": {
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
         "wrappy": "1"
       }
     },
-    "parse-cache-control": {
+    "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
-      "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104="
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-    },
-    "path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU="
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I="
-    },
-    "promise": {
-      "version": "8.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/promise/-/promise-8.1.0.tgz",
-      "integrity": "sha1-aXwlw9/nQ13Xn81Yw4oTWIjq8F4=",
-      "requires": {
-        "asap": "~2.0.6"
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "q": {
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "license": "MIT"
+    },
+    "node_modules/q": {
       "version": "1.5.1",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
-    },
-    "qs": {
-      "version": "6.10.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/qs/-/qs-6.10.1.tgz",
-      "integrity": "sha1-STFIL6jWR6Wqt5nFJx0hM7mB+2o=",
-      "requires": {
-        "side-channel": "^1.0.4"
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
       }
     },
-    "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "rechoir": {
+    "node_modules/rechoir": {
       "version": "0.6.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "requires": {
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
+      "dependencies": {
         "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
-    "resolve": {
-      "version": "1.20.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha1-YpoBP7P3B1XW8LeTXMHCxTeLGXU=",
-      "requires": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
+    "node_modules/sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "license": "WTFPL OR ISC",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
     },
-    "semver": {
-      "version": "5.7.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc="
+    "node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
     },
-    "shelljs": {
-      "version": "0.8.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/shelljs/-/shelljs-0.8.4.tgz",
-      "integrity": "sha1-3naE/ut2f4cWsyYHiooAh1iQ48I=",
-      "requires": {
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
         "glob": "^7.0.0",
         "interpret": "^1.0.0",
         "rechoir": "^0.6.2"
-      }
-    },
-    "side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha1-785cj9wQTudRslxY1CkAEfpeos8=",
-      "requires": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "requires": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "sync-request": {
-      "version": "6.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/sync-request/-/sync-request-6.1.0.tgz",
-      "integrity": "sha1-6WIXVlteULv/4XmGi6dVMvtZfmg=",
-      "requires": {
-        "http-response-object": "^3.0.1",
-        "sync-rpc": "^1.2.1",
-        "then-request": "^6.0.0"
-      }
-    },
-    "sync-rpc": {
-      "version": "1.3.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/sync-rpc/-/sync-rpc-1.3.6.tgz",
-      "integrity": "sha1-suiyVQoSzLxx34ZEgQUp3raGZac=",
-      "requires": {
-        "get-port": "^3.1.0"
-      }
-    },
-    "then-request": {
-      "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/then-request/-/then-request-6.0.2.tgz",
-      "integrity": "sha1-7Bjdi1ykOq7ly5L35MFjDpUNTww=",
-      "requires": {
-        "@types/concat-stream": "^1.6.0",
-        "@types/form-data": "0.0.33",
-        "@types/node": "^8.0.0",
-        "@types/qs": "^6.2.31",
-        "caseless": "~0.12.0",
-        "concat-stream": "^1.6.0",
-        "form-data": "^2.2.0",
-        "http-basic": "^8.1.1",
-        "http-response-object": "^3.0.1",
-        "promise": "^8.0.0",
-        "qs": "^6.4.0"
       },
-      "dependencies": {
-        "@types/node": {
-          "version": "8.10.66",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/node/-/node-8.10.66.tgz",
-          "integrity": "sha1-3QNdQJ3zIqzIPf9ipgLxKleDu7M="
-        }
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "universalify": {
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "license": "WTFPL",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "node_modules/universalify": {
       "version": "2.0.0",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha1-daSYTv7cSwiXXFrrc/Uw0C3yVxc="
+      "integrity": "sha1-daSYTv7cSwiXXFrrc/Uw0C3yVxc=",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+      "license": "(WTFPL OR MIT)"
     },
-    "uuid": {
+    "node_modules/uuid": {
       "version": "3.4.0",
       "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4="
+      "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
     },
-    "wrappy": {
+    "node_modules/wrappy": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     }
   }
 }

--- a/Tasks/LoadYamlVariables/package.json
+++ b/Tasks/LoadYamlVariables/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "dependencies": {
-    "azure-pipelines-task-lib": "^3.1.10",
+    "azure-pipelines-task-lib": "^4.13.0",
     "fs-extra": "^10.0.0",
     "js-yaml": "^4.1.0"
   }

--- a/Tasks/LoadYamlVariables/task.json
+++ b/Tasks/LoadYamlVariables/task.json
@@ -18,7 +18,7 @@
     "demands": [
         "npm"
     ],
-    "minimumAgentVersion": "1.91.0",
+    "minimumAgentVersion": "2.144.0",
     "instanceNameFormat": "Load variables from $(YamlSource) with prefix : $(VariablePrefix)",
     "inputs": [
         {
@@ -48,6 +48,10 @@
     ],
     "execution": {
         "Node10": {
+            "target": "loadyamlvariables.js",
+            "argumentFormat": ""
+        },
+        "Node20_1": {
             "target": "loadyamlvariables.js",
             "argumentFormat": ""
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,241 +1,263 @@
 {
   "name": "gl-vsts-tasks-variables",
   "version": "0.1.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "@babel/code-frame": {
-      "version": "7.16.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@babel/code-frame/-/code-frame-7.16.0.tgz",
-      "integrity": "sha1-DfyAMJvuyEEeZecGRhxAiwu5tDE=",
-      "dev": true,
-      "requires": {
-        "@babel/highlight": "^7.16.0"
+  "packages": {
+    "": {
+      "name": "gl-vsts-tasks-variables",
+      "version": "0.1.0",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@types/fs-extra": "^9.0.13",
+        "@types/jasmine": "^3.10.2",
+        "@types/js-yaml": "^4.0.5",
+        "@types/micromatch": "^4.0.2",
+        "@types/node": "^20.3.1",
+        "@types/parse-glob": "^3.0.29",
+        "@types/q": "^1.5.5",
+        "async": "^3.2.2",
+        "azure-pipelines-task-lib": "^4.13.0",
+        "gl-vsts-tasks-build-scripts": "^0.6.0",
+        "karma": "^6.3.9",
+        "npm-run-all": "^4.1.5",
+        "typescript": "5.1.6"
       }
     },
-    "@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha1-Ig35k7/pBKSmsCq08zhaXr9uI4k=",
-      "dev": true
-    },
-    "@babel/highlight": {
-      "version": "7.16.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@babel/highlight/-/highlight-7.16.0.tgz",
-      "integrity": "sha1-bOsysspLj182H7f9gh4/3fShclo=",
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
       "dev": true,
-      "requires": {
-        "@babel/helper-validator-identifier": "^7.15.7",
-        "chalk": "^2.0.0",
-        "js-tokens": "^4.0.0"
-      },
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/braces": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/braces/-/braces-3.0.5.tgz",
+      "integrity": "sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
-    "@types/braces": {
-      "version": "3.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/braces/-/braces-3.0.1.tgz",
-      "integrity": "sha1-WihNGTz8Yauy5aUNNuu8UNlCoys=",
-      "dev": true
-    },
-    "@types/component-emitter": {
-      "version": "1.2.11",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/component-emitter/-/component-emitter-1.2.11.tgz",
-      "integrity": "sha1-UNR9QrNHJTgXo5cJ/vA85moQhQY=",
-      "dev": true
-    },
-    "@types/concat-stream": {
-      "version": "1.6.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/concat-stream/-/concat-stream-1.6.1.tgz",
-      "integrity": "sha1-JLz8EB7PaOiGqu3OYN/XS2MqG3Q=",
-      "dev": true,
-      "requires": {
         "@types/node": "*"
       }
     },
-    "@types/cookie": {
-      "version": "0.4.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha1-v9AsHyIkVnZ2wVRRmfh8OoYdh40=",
-      "dev": true
-    },
-    "@types/cors": {
-      "version": "2.8.12",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/cors/-/cors-2.8.12.tgz",
-      "integrity": "sha1-ayxRCnrXA56Y57jT1lmPQ1nlwIA=",
-      "dev": true
-    },
-    "@types/form-data": {
-      "version": "0.0.33",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/form-data/-/form-data-0.0.33.tgz",
-      "integrity": "sha1-yayFsqX9GENbjIXZ7LUObWyJP/g=",
-      "dev": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@types/fs-extra": {
+    "node_modules/@types/fs-extra": {
       "version": "9.0.13",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/fs-extra/-/fs-extra-9.0.13.tgz",
-      "integrity": "sha1-dZT7rgT+fxkYzos9IT90/0SsH0U=",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "@types/node": "*"
       }
     },
-    "@types/jasmine": {
-      "version": "3.10.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/jasmine/-/jasmine-3.10.2.tgz",
-      "integrity": "sha1-G5+bqa17/X0yL37Z2HUyILHIS1I=",
-      "dev": true
-    },
-    "@types/js-yaml": {
-      "version": "4.0.5",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/js-yaml/-/js-yaml-4.0.5.tgz",
-      "integrity": "sha1-c43TkKbsxUQvNefwP6FDE1P34Tg=",
-      "dev": true
-    },
-    "@types/micromatch": {
-      "version": "4.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/micromatch/-/micromatch-4.0.2.tgz",
-      "integrity": "sha1-zinIsWanO/mApXJ7HkpNCZllFR0=",
+    "node_modules/@types/jasmine": {
+      "version": "3.10.18",
+      "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-3.10.18.tgz",
+      "integrity": "sha512-jOk52a1Kz+1oU5fNWwAcNe64/GsE7r/Q6ronwDox0D3ETo/cr4ICMQyeXrj7G6FPW1n8YjRoAZA2F0XBr6GicQ==",
       "dev": true,
-      "requires": {
+      "license": "MIT"
+    },
+    "node_modules/@types/js-yaml": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
+      "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/micromatch": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/micromatch/-/micromatch-4.0.10.tgz",
+      "integrity": "sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "@types/braces": "*"
       }
     },
-    "@types/minimist": {
-      "version": "1.2.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/minimist/-/minimist-1.2.2.tgz",
-      "integrity": "sha1-7nceK6Sz3Fs3KTXVSf2WF780W4w=",
-      "dev": true
-    },
-    "@types/node": {
-      "version": "16.11.11",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/node/-/node-16.11.11.tgz",
-      "integrity": "sha1-bqc0Lfs3nqEhCDW62oezxRISAjQ=",
-      "dev": true
-    },
-    "@types/normalize-package-data": {
-      "version": "2.4.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
-      "integrity": "sha1-0zV0eaD9/dWQf+Z+F+CoXJBuEwE=",
-      "dev": true
-    },
-    "@types/parse-glob": {
-      "version": "3.0.29",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/parse-glob/-/parse-glob-3.0.29.tgz",
-      "integrity": "sha1-akDsfr0kGO5p7jl+SOQhaSaKEL8=",
-      "dev": true
-    },
-    "@types/q": {
-      "version": "1.5.5",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/q/-/q-1.5.5.tgz",
-      "integrity": "sha1-daKo59irSyMEFFBdkjNdHctTpt8=",
-      "dev": true
-    },
-    "@types/qs": {
-      "version": "6.9.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/qs/-/qs-6.9.7.tgz",
-      "integrity": "sha1-Y7t9Bn2xB8weRXwwO8JdUR/r9ss=",
-      "dev": true
-    },
-    "accepts": {
-      "version": "1.3.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/accepts/-/accepts-1.3.7.tgz",
-      "integrity": "sha1-UxvHJlF6OytB+FACHGzBXqq1B80=",
+    "node_modules/@types/node": {
+      "version": "20.19.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
+      "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
       "dev": true,
-      "requires": {
-        "mime-types": "~2.1.24",
-        "negotiator": "0.6.2"
-      }
-    },
-    "ansi-align": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ansi-align/-/ansi-align-1.1.0.tgz",
-      "integrity": "sha1-LwwWWIKXOa3V67FeawxuNCPwFro=",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.1"
-      }
-    },
-    "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
-    },
-    "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
-    },
-    "anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha1-wFV8CWrzLxBhmPT04qODU343hxY=",
-      "dev": true,
-      "requires": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
+      "license": "MIT",
       "dependencies": {
-        "normalize-path": {
-          "version": "3.0.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
-          "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
-          "dev": true
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/parse-glob": {
+      "version": "3.0.32",
+      "resolved": "https://registry.npmjs.org/@types/parse-glob/-/parse-glob-3.0.32.tgz",
+      "integrity": "sha512-n4xmml2WKR12XeQprN8L/sfiVPa8FHS3k+fxp4kSr/PA2GsGUgFND+bvISJxM0y5QdvzNEGjEVU3eIrcKks/pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/q": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.8.tgz",
+      "integrity": "sha512-hroOstUScF6zhIi+5+x0dzqrHA1EJi+Irri6b1fxolMTqqHIV/Cg77EtnQcZqZCu8hR3mX2BzIxN4/GzI68Kfw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
         }
       }
     },
-    "app-root-path": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/app-root-path/-/app-root-path-1.0.0.tgz",
-      "integrity": "sha1-LHKZF0vGHLhv46SnmOAeSTt9U30=",
-      "dev": true
-    },
-    "arch": {
-      "version": "2.2.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/arch/-/arch-2.2.0.tgz",
-      "integrity": "sha1-G8R4GPMFdk8jqzMGsL/AhsWinRE=",
-      "dev": true
-    },
-    "archiver": {
-      "version": "2.0.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/archiver/-/archiver-2.0.3.tgz",
-      "integrity": "sha1-tDYLtYSvFDeZGUJxbyHXxSPR270=",
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
-      "requires": {
+      "license": "MIT"
+    },
+    "node_modules/ansi-align": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-1.1.0.tgz",
+      "integrity": "sha512-ncgIO/ZeFcsh3cye0NgGPb5h/3vCiKJxp6HvPtqsFvEL/4b/G2tNgrr8EOYN5RSVnGx69k8dFYSBG/w1yKX58Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^1.0.1"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/app-root-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-1.0.0.tgz",
+      "integrity": "sha512-OKap/l8oElrynRMEbtwubVW5M5G16LKz9Wxo0DYBmce595lao0EbmD4O82j7qo9yukVWMTDriWvgrbt6yPnb9A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/arch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/archiver": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-2.0.3.tgz",
+      "integrity": "sha512-TqHyk3if+6c3elGaLZu+wPMnaY2hm8PYmgmt1J34NZlFyHKwTiSugJFLMfb0K1xbYAgRtDJjjyW3T2p2B1f//g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "archiver-utils": "^1.3.0",
         "async": "^2.0.0",
         "buffer-crc32": "^0.2.1",
@@ -246,183 +268,278 @@
         "walkdir": "^0.0.11",
         "zip-stream": "^1.2.0"
       },
-      "dependencies": {
-        "async": {
-          "version": "2.6.3",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/async/-/async-2.6.3.tgz",
-          "integrity": "sha1-1yYl4jRKNlbjo61Pp0n6gymdgv8=",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        }
+      "engines": {
+        "node": ">= 4"
       }
     },
-    "archiver-utils": {
+    "node_modules/archiver-utils": {
       "version": "1.3.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/archiver-utils/-/archiver-utils-1.3.0.tgz",
-      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+      "integrity": "sha512-h+hTREBXcW5e1L9RihGXdH4PHHdGipG/jE2sMZrqIH6BmZAxeGU5IWjVsKhokdCSWX7km6Kkh406zZNEElHFPQ==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "glob": "^7.0.0",
         "graceful-fs": "^4.1.0",
         "lazystream": "^1.0.0",
         "lodash": "^4.8.0",
         "normalize-path": "^2.0.0",
         "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
-    "arrify": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/arrify/-/arrify-1.0.1.tgz",
-      "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-      "dev": true
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
-      "dev": true
-    },
-    "async": {
-      "version": "3.2.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/async/-/async-3.2.2.tgz",
-      "integrity": "sha1-LrdnEDS7IZTUXTDjHiTsfn+WcM0=",
-      "dev": true
-    },
-    "async-each-series": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/async-each-series/-/async-each-series-1.1.0.tgz",
-      "integrity": "sha1-9C/YFV048hpbjqB8KOBj7RcAsTg=",
-      "dev": true
-    },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
-    },
-    "available-typed-arrays": {
-      "version": "1.0.5",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha1-kvlWFlAQadB9EO2y/DfT4cZRI7c=",
-      "dev": true
-    },
-    "azure-devops-node-api": {
-      "version": "8.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/azure-devops-node-api/-/azure-devops-node-api-8.1.1.tgz",
-      "integrity": "sha1-+yTXg+DqDhG7AM4p0NMrnVjKpqg=",
+    "node_modules/archiver-utils/node_modules/normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
+        "remove-trailing-separator": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/archiver/node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.reduce": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/array.prototype.reduce/-/array.prototype.reduce-1.0.8.tgz",
+      "integrity": "sha512-DwuEqgXFBwbmZSRqt3BpQigWNUoqw9Ml2dTWdF3B2zQlQX4OeUE0zyuzX0fX0IbTvjdkZbcBTU3idgpO78qkTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-array-method-boxes-properly": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "is-string": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-each-series": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/async-each-series/-/async-each-series-1.1.0.tgz",
+      "integrity": "sha512-/VIpPVIJJlJObJiXkHBJ1RhjDtydBRG/3/dWpsXoVGOShNw5tameXnC7Yys+wpb0p/myItxGmSGgNi/dNlsIiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/azure-devops-node-api": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/azure-devops-node-api/-/azure-devops-node-api-8.1.1.tgz",
+      "integrity": "sha512-TIb69NbHOJ/OTvfI1iazMzw/wG9A+ORCYibZCf5wDQFUyYzjCNVUA9QskAW1BGOulwyulGpqWXClCo4KoBaP0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "tunnel": "0.0.4",
         "typed-rest-client": "1.2.0",
         "underscore": "1.8.3"
       }
     },
-    "azure-pipelines-task-lib": {
-      "version": "3.1.10",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/azure-pipelines-task-lib/-/azure-pipelines-task-lib-3.1.10.tgz",
-      "integrity": "sha1-NLoir8okcv06I2bd9XTBzxH7L2Y=",
+    "node_modules/azure-pipelines-task-lib": {
+      "version": "4.17.3",
+      "resolved": "https://registry.npmjs.org/azure-pipelines-task-lib/-/azure-pipelines-task-lib-4.17.3.tgz",
+      "integrity": "sha512-UxfH5pk3uOHTi9TtLtdDyugQVkFES5A836ZEePjcs3jYyxm3EJ6IlFYq6gbfd6mNBhrM9fxG2u/MFYIJ+Z0cxQ==",
       "dev": true,
-      "requires": {
-        "minimatch": "3.0.4",
-        "mockery": "^1.7.0",
-        "q": "^1.5.1",
-        "semver": "^5.1.0",
-        "shelljs": "^0.8.4",
-        "sync-request": "6.1.0",
-        "uuid": "^3.0.1"
-      },
+      "license": "MIT",
       "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
-          "dev": true
-        },
-        "shelljs": {
-          "version": "0.8.4",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/shelljs/-/shelljs-0.8.4.tgz",
-          "integrity": "sha1-3naE/ut2f4cWsyYHiooAh1iQ48I=",
-          "dev": true,
-          "requires": {
-            "glob": "^7.0.0",
-            "interpret": "^1.0.0",
-            "rechoir": "^0.6.2"
-          }
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
-          "dev": true
-        }
+        "adm-zip": "^0.5.10",
+        "minimatch": "3.0.5",
+        "nodejs-file-downloader": "^4.11.1",
+        "q": "^1.5.1",
+        "semver": "^5.7.2",
+        "shelljs": "^0.8.5",
+        "uuid": "^3.0.1"
       }
     },
-    "balanced-match": {
+    "node_modules/balanced-match": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha1-6D46fj8wCzTLnYf2FfoMvzV2kO4=",
-      "dev": true
-    },
-    "base64-arraybuffer": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/base64-arraybuffer/-/base64-arraybuffer-1.0.1.tgz",
-      "integrity": "sha1-h70TUlYm20qYOOAKUIwrc+/PNIw=",
-      "dev": true
-    },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha1-GxtEAWClv3rUC2UPCVljSBkDkwo=",
-      "dev": true
-    },
-    "base64id": {
-      "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/base64id/-/base64id-2.0.0.tgz",
-      "integrity": "sha1-J3Csa8R9MSr5eov5pjQ0LgzSXLY=",
-      "dev": true
-    },
-    "binary-extensions": {
-      "version": "2.2.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha1-dfUC7q+f/eQvyYgpZFvk6na9ni0=",
-      "dev": true
-    },
-    "bl": {
-      "version": "1.2.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/bl/-/bl-1.2.3.tgz",
-      "integrity": "sha1-Ho3YAULqyA1xWMnczAR/tiDgNec=",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
-      "requires": {
+      "license": "MIT"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+      "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
       }
     },
-    "body-parser": {
-      "version": "1.19.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/body-parser/-/body-parser-1.19.0.tgz",
-      "integrity": "sha1-lrJwnlfJxOCab9Zqj9l5hE9p8Io=",
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "dev": true,
-      "requires": {
-        "bytes": "3.1.0",
-        "content-type": "~1.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
         "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "1.7.2",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
-        "on-finished": "~2.3.0",
-        "qs": "6.7.0",
-        "raw-body": "2.4.0",
-        "type-is": "~1.6.17"
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
-    "boxen": {
+    "node_modules/boxen": {
       "version": "0.6.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/boxen/-/boxen-0.6.0.tgz",
-      "integrity": "sha1-g2TUJIrDT/DvGy8r9JpsYM4NgbY=",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-0.6.0.tgz",
+      "integrity": "sha512-yL8sYzt0avlYGOY6LqtECkGrJOY3cCLAbFPaNfgE+4fD45ZrdYqLdY8yF4bqyTkpfW9e6W0YqBkN7dIn/PrZoA==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "ansi-align": "^1.1.0",
         "camelcase": "^2.1.0",
         "chalk": "^1.1.1",
@@ -432,328 +549,412 @@
         "repeating": "^2.0.0",
         "string-width": "^1.0.1",
         "widest-line": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
-    "braces": {
-      "version": "3.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha1-NFThpGLujVmeI23zNs2epPiv4Qc=",
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
-      "requires": {
-        "fill-range": "^7.0.1"
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "buffer": {
+    "node_modules/buffer": {
       "version": "5.7.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha1-umLnwTEzBTWCGXFghRqPZI6Z7tA=",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
       "dev": true,
-      "requires": {
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
     },
-    "buffer-alloc": {
+    "node_modules/buffer-alloc": {
       "version": "1.2.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha1-iQ3ZDZI6hz4I4Q5f1RpX5bfM4Ow=",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "buffer-alloc-unsafe": "^1.1.0",
         "buffer-fill": "^1.0.0"
       }
     },
-    "buffer-alloc-unsafe": {
+    "node_modules/buffer-alloc-unsafe": {
       "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha1-vX3CauKXLQ7aJTvgYdupkjScGfA=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "dev": true,
+      "license": "MIT"
     },
-    "buffer-crc32": {
+    "node_modules/buffer-crc32": {
       "version": "0.2.13",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
-    "buffer-fill": {
+    "node_modules/buffer-fill": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-      "dev": true
-    },
-    "buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha1-KxRqb9cugLT1XSVfNe1Zo6mkG9U=",
-      "dev": true
-    },
-    "bytes": {
-      "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/bytes/-/bytes-3.1.0.tgz",
-      "integrity": "sha1-9s95M6Ng4FiPqf3oVlHNx/gF0fY=",
-      "dev": true
-    },
-    "call-bind": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/call-bind/-/call-bind-1.0.2.tgz",
-      "integrity": "sha1-sdTonmiBGcPJqQOtMKuy9qkZvjw=",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha512-T7zexNBwiiaCOGDg9xNX9PBmjrubblRkENuptryuI64URkXDFum9il/JGL8Lm8wYfAXpredVXXZz7eMHilimiQ==",
       "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.0.2"
+      "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
-    "camelcase": {
-      "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
-      "dev": true
-    },
-    "camelcase-keys": {
-      "version": "7.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/camelcase-keys/-/camelcase-keys-7.0.1.tgz",
-      "integrity": "sha1-Wlfm37P2x5KdrRVZnuRHan6aOy0=",
+    "node_modules/call-bind": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "dev": true,
-      "requires": {
-        "camelcase": "^6.2.0",
-        "map-obj": "^4.1.0",
-        "quick-lru": "^5.1.1",
-        "type-fest": "^1.2.1"
-      },
+      "license": "MIT",
       "dependencies": {
-        "camelcase": {
-          "version": "6.2.1",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/camelcase/-/camelcase-6.2.1.tgz",
-          "integrity": "sha1-JQ/TUM/VVdDSFgsdUVEOr4Mm6G4=",
-          "dev": true
-        }
+        "call-bind-apply-helpers": "^1.0.0",
+        "es-define-property": "^1.0.0",
+        "get-intrinsic": "^1.2.4",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "capture-stack-trace": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
-      "integrity": "sha1-psC74fOPOqC5Ijjstv9Cw0TUE10=",
-      "dev": true
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-      "dev": true
-    },
-    "chalk": {
-      "version": "1.1.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha512-DLIsRzJVBQu72meAKPkWQOLcujdXT32hwdfnkI1frSiSRMK1MofjKHf+MEx0SB6fjEFXL8fBDv1dKymBlOp4Qw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/capture-stack-trace": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.2.tgz",
+      "integrity": "sha512-X/WM2UQs6VMHUtjUDnZTRI+i1crWteJySFzr9UpGoQa4WQffXVTTXuekjl7TjZRlcF2XfjgITT0HxZ9RnxeT0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "ansi-styles": "^2.2.1",
         "escape-string-regexp": "^1.0.2",
         "has-ansi": "^2.0.0",
         "strip-ansi": "^3.0.0",
         "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha1-26OXb8rbAW9m/TZQIdkWANAcHnU=",
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
         "readdirp": "~3.6.0"
       },
-      "dependencies": {
-        "normalize-path": {
-          "version": "3.0.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/normalize-path/-/normalize-path-3.0.0.tgz",
-          "integrity": "sha1-Dc1p/yOhybEf0JeDFmRKA4ghamU=",
-          "dev": true
-        }
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
       }
     },
-    "cli-boxes": {
+    "node_modules/cli-boxes": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
-      "dev": true
-    },
-    "cli-color": {
-      "version": "0.3.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/cli-color/-/cli-color-0.3.2.tgz",
-      "integrity": "sha1-dfpfcowwjMSsWUsF4GzF2A2szYY=",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
+      "integrity": "sha512-3Fo5wu8Ytle8q9iCzS4D2MWVL2X7JVWRiS1BnXbTFDhS9c/REkM9vd1AmabsoZoY5/dGi5TT9iKL8Kb6DeBRQg==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-color": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.2.tgz",
+      "integrity": "sha512-Ys/nDhHNRcxrS4EUI2RS/QCUE+61AMuEOj3sWDX+EIHkJWj+4XkRbOdwdxJteAJKjXYBbeFJMtfaEPd1MBF9pQ==",
+      "dev": true,
+      "dependencies": {
         "d": "~0.1.1",
         "es5-ext": "~0.10.2",
         "memoizee": "0.3.x",
         "timers-ext": "0.1.x"
       }
     },
-    "clipboardy": {
+    "node_modules/clipboardy": {
       "version": "1.2.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/clipboardy/-/clipboardy-1.2.3.tgz",
-      "integrity": "sha1-BSY2G/eHJMHyC+JI1CjjZUM8B+8=",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
+      "integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "arch": "^2.1.0",
         "execa": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "cliui": {
+    "node_modules/cliui": {
       "version": "7.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha1-oCZe5lVHb8gHrqnfPfjfd4OAi08=",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
       "dev": true,
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^7.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        }
       }
     },
-    "clui": {
-      "version": "0.3.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/clui/-/clui-0.3.6.tgz",
-      "integrity": "sha1-jh5c6nMypuVAg/WdoMy+HW8vp4c=",
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clui": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/clui/-/clui-0.3.6.tgz",
+      "integrity": "sha512-Z4UbgZILlIAjkEkZiDOa2aoYjohKx7fa6DxIh6cE9A6WNWZ61iXfQc6CmdC9SKdS5nO0P0UyQ+WfoXfB65e3HQ==",
+      "dev": true,
+      "dependencies": {
         "cli-color": "0.3.2"
       }
     },
-    "code-point-at": {
+    "node_modules/code-point-at": {
       "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
-    },
-    "color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha1-u3GFBpDh8TZWfeYp0tVHHe2kweg=",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "color-name": "1.1.3"
       }
     },
-    "color-name": {
+    "node_modules/color-name": {
       "version": "1.1.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "colors": {
-      "version": "1.3.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/colors/-/colors-1.3.3.tgz",
-      "integrity": "sha1-OeAF1Uav4B4B+cTKj6UPaGoBIF0=",
-      "dev": true
-    },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha1-w9RaizT9cwYxoRCoolIGgrMdWn8=",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
       "dev": true,
-      "requires": {
-        "delayed-stream": "~1.0.0"
+      "license": "MIT"
+    },
+    "node_modules/colors": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
-    "commander": {
+    "node_modules/commander": {
       "version": "2.20.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha1-/UhehMA+tIgcIHIrpIA16FMa6zM=",
-      "dev": true
-    },
-    "component-emitter": {
-      "version": "1.3.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha1-FuQHD7qK4ptnnyIVhT7hgasuq8A=",
-      "dev": true
-    },
-    "compress-commons": {
-      "version": "1.2.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/compress-commons/-/compress-commons-1.2.2.tgz",
-      "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
-      "requires": {
+      "license": "MIT"
+    },
+    "node_modules/compress-commons": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+      "integrity": "sha512-SLTU8iWWmcORfUN+4351Z2aZXKJe1tr0jSilPMCZlLPzpdTXnkBW1LevW/MfuANBKJek8Xu9ggqrtVmQrChLtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "buffer-crc32": "^0.2.1",
         "crc32-stream": "^2.0.0",
         "normalize-path": "^2.0.0",
         "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
-    "concat-map": {
+    "node_modules/compress-commons/node_modules/normalize-path": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "remove-trailing-separator": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/concat-map": {
       "version": "0.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
-    },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      }
+      "license": "MIT"
     },
-    "configstore": {
+    "node_modules/configstore": {
       "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/configstore/-/configstore-2.1.0.tgz",
-      "integrity": "sha1-c3o6cDbpiGECqmCZ5HuzOrGroaE=",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-2.1.0.tgz",
+      "integrity": "sha512-BOCxwwxF5WPspp1OBq9j0JLyL5JgJOTssz9PdOHr8VWjFijaC3PpjU48vFEX3uxx8sTusnVQckLbNzBq6fmkGw==",
       "dev": true,
-      "requires": {
+      "license": "BSD-2-Clause",
+      "dependencies": {
         "dot-prop": "^3.0.0",
         "graceful-fs": "^4.1.2",
         "mkdirp": "^0.5.0",
@@ -763,570 +964,915 @@
         "uuid": "^2.0.1",
         "write-file-atomic": "^1.1.2",
         "xdg-basedir": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "connect": {
-      "version": "3.7.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/connect/-/connect-3.7.0.tgz",
-      "integrity": "sha1-XUk0iRDKpeB6AYALAw0MNfIEhPg=",
+    "node_modules/configstore/node_modules/uuid": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+      "integrity": "sha512-FULf7fayPdpASncVy4DLh3xydlXEJJpvIELjYjNeQWYUZ9pclcpvCZSr2gkmN2FrrGcI7G/cJsIEwk5/8vfXpg==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
       "dev": true,
-      "requires": {
+      "license": "MIT"
+    },
+    "node_modules/connect": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/connect/-/connect-3.7.0.tgz",
+      "integrity": "sha512-ZqRXc+tZukToSNmh5C2iWMSoV3X1YUcPbqEM4DkEG5tNQXrQUZCNVGGv3IuicnkMtPfGf3Xtp8WCXs295iQ1pQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "debug": "2.6.9",
         "finalhandler": "1.1.2",
         "parseurl": "~1.3.3",
         "utils-merge": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
-    "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js=",
-      "dev": true
-    },
-    "cookie": {
-      "version": "0.4.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/cookie/-/cookie-0.4.1.tgz",
-      "integrity": "sha1-r9cT/ibr0hupXOth+agRblClN9E=",
-      "dev": true
-    },
-    "core-js": {
-      "version": "2.3.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/core-js/-/core-js-2.3.0.tgz",
-      "integrity": "sha1-+rg/uwstjchfpjbEudNMdUIMbWU=",
-      "dev": true
-    },
-    "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha1-pgQtNjTCsn6TKPg3uWX6yDgI24U=",
-      "dev": true
-    },
-    "cors": {
-      "version": "2.8.5",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/cors/-/cors-2.8.5.tgz",
-      "integrity": "sha1-6sEdpRWS3Ya58G9uesKTs9+HXSk=",
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/core-js": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.3.0.tgz",
+      "integrity": "sha512-N41UFUZNqoTSGUSyL7kiStAkH31Hxq197A4Gp9MxTZfAd52pXod7VM7kWiRP0J0YpQDeaE4SLsb+2OGgtgvUEw==",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "object-assign": "^4",
         "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
-    "crc": {
+    "node_modules/crc": {
       "version": "3.8.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/crc/-/crc-3.8.0.tgz",
-      "integrity": "sha1-rWAmnCyFb4wpnixMwN5FVpFAVsY=",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "buffer": "^5.1.0"
       }
     },
-    "crc32-stream": {
+    "node_modules/crc32-stream": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/crc32-stream/-/crc32-stream-2.0.0.tgz",
-      "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+      "integrity": "sha512-UjZSqFCbn+jZUHJIh6Y3vMF7EJLcJWNm4tKDf2peJRwlZKHvkkvOMTvAei6zjU9gO1xONVr3rRFw0gixm2eUng==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "crc": "^3.4.4",
         "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
-    "create-error-class": {
+    "node_modules/create-error-class": {
       "version": "3.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/create-error-class/-/create-error-class-3.0.2.tgz",
-      "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha512-gYTKKexFO3kh200H1Nit76sRwRtOY32vQd3jpAQKpLtZqyNsSQNfI4N7o3eP2wUjV35pTWKRYqFUDBvUha/Pkw==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "capture-stack-trace": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+    "node_modules/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==",
       "dev": true,
-      "requires": {
-        "lru-cache": "^4.0.1",
+      "license": "MIT",
+      "dependencies": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
+      },
+      "engines": {
+        "node": ">=4.8"
       }
     },
-    "custom-event": {
+    "node_modules/custom-event": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/custom-event/-/custom-event-1.0.1.tgz",
-      "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
-      "dev": true
-    },
-    "cycle": {
-      "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI=",
-      "dev": true
-    },
-    "d": {
-      "version": "0.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/d/-/d-0.1.1.tgz",
-      "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
+      "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
+      "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg==",
       "dev": true,
-      "requires": {
+      "license": "MIT"
+    },
+    "node_modules/cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha512-TVF6svNzeQCOpjCqsy0/CSy8VgObG3wXusJ73xW2GbG5rGx7lC8zxDSURicsXI2UsGdi2L0QNRCi745/wUDvsA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/d": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+      "integrity": "sha512-0SdM9V9pd/OXJHoWmTfNPTAeD+lw6ZqHg+isPyBFuJsZLSE0Ygg1cYZ/0l6DrKQXMOqGOu1oWupMoOfoRfMZrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "es5-ext": "~0.10.2"
       }
     },
-    "date-format": {
-      "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/date-format/-/date-format-3.0.0.tgz",
-      "integrity": "sha1-64eANlx9KxURB4+0keZHl4DzrZU=",
-      "dev": true
-    },
-    "dateformat": {
-      "version": "1.0.11",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/dateformat/-/dateformat-1.0.11.tgz",
-      "integrity": "sha1-8ny+56ASu/uC6gUVYtOXf2CT27E=",
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
       "dev": true,
-      "requires": {
-        "get-stdin": "*",
-        "meow": "*"
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "debug": {
-      "version": "2.6.9",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-format": {
+      "version": "4.0.14",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.14.tgz",
+      "integrity": "sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/dateformat": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
+      "integrity": "sha512-5zcI+Qoul0QgiCcjzsobs9G1c+vHCNaYB2NGa57ZbVnP7bZeKJJgoM/K+I/obaHAmyEL0J8hJafbQ+HFSZnzZA==",
+      "dev": true,
+      "dependencies": {
+        "get-stdin": "*",
+        "meow": "*"
+      },
+      "bin": {
+        "dateformat": "bin/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "ms": "2.0.0"
       }
     },
-    "decamelize": {
-      "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/decamelize/-/decamelize-5.0.1.tgz",
-      "integrity": "sha1-2xGpLljHQe8zn7Ciho2KBqmnsek=",
-      "dev": true
-    },
-    "decamelize-keys": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+    "node_modules/deep-equal": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.3.tgz",
+      "integrity": "sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==",
       "dev": true,
-      "requires": {
-        "decamelize": "^1.1.0",
-        "map-obj": "^1.0.0"
-      },
+      "license": "MIT",
       "dependencies": {
-        "decamelize": {
-          "version": "1.2.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/decamelize/-/decamelize-1.2.0.tgz",
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-          "dev": true
-        },
-        "map-obj": {
-          "version": "1.0.1",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
-          "dev": true
-        }
-      }
-    },
-    "deep-equal": {
-      "version": "2.0.5",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/deep-equal/-/deep-equal-2.0.5.tgz",
-      "integrity": "sha1-Vc0v4ybYP5y/cmHvDgYLP3JMXLk=",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "es-get-iterator": "^1.1.1",
-        "get-intrinsic": "^1.0.1",
-        "is-arguments": "^1.0.4",
-        "is-date-object": "^1.0.2",
-        "is-regex": "^1.1.1",
+        "array-buffer-byte-length": "^1.0.0",
+        "call-bind": "^1.0.5",
+        "es-get-iterator": "^1.1.3",
+        "get-intrinsic": "^1.2.2",
+        "is-arguments": "^1.1.1",
+        "is-array-buffer": "^3.0.2",
+        "is-date-object": "^1.0.5",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
         "isarray": "^2.0.5",
-        "object-is": "^1.1.4",
+        "object-is": "^1.1.5",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
-        "regexp.prototype.flags": "^1.3.0",
-        "side-channel": "^1.0.3",
-        "which-boxed-primitive": "^1.0.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.5.1",
+        "side-channel": "^1.0.4",
+        "which-boxed-primitive": "^1.0.2",
         "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.2"
+        "which-typed-array": "^1.1.13"
       },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM=",
-          "dev": true
-        }
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "deep-extend": {
+    "node_modules/deep-extend": {
       "version": "0.6.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=",
-      "dev": true
-    },
-    "define-properties": {
-      "version": "1.1.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/define-properties/-/define-properties-1.1.3.tgz",
-      "integrity": "sha1-z4jabL7ib+bbcJT2HYcMvYTO6fE=",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true,
-      "requires": {
-        "object-keys": "^1.0.12"
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
-    },
-    "depd": {
-      "version": "1.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-      "dev": true
-    },
-    "di": {
-      "version": "0.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/di/-/di-0.0.1.tgz",
-      "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
-      "dev": true
-    },
-    "dom-serialize": {
-      "version": "2.2.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/dom-serialize/-/dom-serialize-2.2.1.tgz",
-      "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/di": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
+      "integrity": "sha512-uJaamHkagcZtHPqCIHZxnFrXlunQXgBOsZSUOWwFw31QJCAbyTBoHMW75YOTur5ZNx8pIeAKgf6GWIgaqqiLhA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dom-serialize": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
+      "integrity": "sha512-Yra4DbvoW7/Z6LBN560ZwXMjoNOSAN2wRsKFGc4iBeso+mpIA6qj1vfdf9HpMaKAqG6wXTy+1SYEzmNpKXOSsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "custom-event": "~1.0.0",
         "ent": "~2.2.0",
         "extend": "^3.0.0",
         "void-elements": "^2.0.0"
       }
     },
-    "dot-prop": {
+    "node_modules/dot-prop": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/dot-prop/-/dot-prop-3.0.0.tgz",
-      "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
+      "integrity": "sha512-k4ELWeEU3uCcwub7+dWydqQBRjAjkV9L33HjVRG5Xo2QybI6ja/v+4W73SRi8ubCqJz0l9XsTP1NbewfyqaSlw==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "is-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
         "readable-stream": "^2.0.2"
       }
     },
-    "ee-first": {
+    "node_modules/ee-first": {
       "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-      "dev": true
-    },
-    "emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha1-6Bj9ac5cz8tARZT4QpY79TFkzDc=",
-      "dev": true
-    },
-    "empty-dir": {
-      "version": "0.2.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/empty-dir/-/empty-dir-0.2.1.tgz",
-      "integrity": "sha1-gJ7kih60rRy1EMJXLWb9DthNAas=",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true,
-      "requires": {
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/empty-dir": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/empty-dir/-/empty-dir-0.2.1.tgz",
+      "integrity": "sha512-0f1naHGJh4K6iVG28nRN7SCdfzT18OlpGzHmXw3JGwREb8qmtibHdmRgqx08u4sQfDadezK7kpU3bcIZNSwoZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "fs-exists-sync": "^0.1.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
-    "encodeurl": {
+    "node_modules/encodeurl": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-      "dev": true
-    },
-    "end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha1-WuZKX0UFe682JuwU2gyl5LJDHrA=",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "once": "^1.4.0"
       }
     },
-    "engine.io": {
-      "version": "6.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/engine.io/-/engine.io-6.1.0.tgz",
-      "integrity": "sha1-RZ6rDDckiZ17Y6IMOmg1z5KFeTk=",
+    "node_modules/engine.io": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
+      "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
       "dev": true,
-      "requires": {
-        "@types/cookie": "^0.4.1",
+      "license": "MIT",
+      "dependencies": {
         "@types/cors": "^2.8.12",
         "@types/node": ">=10.0.0",
         "accepts": "~1.3.4",
         "base64id": "2.0.0",
-        "cookie": "~0.4.1",
+        "cookie": "~0.7.2",
         "cors": "~2.8.5",
         "debug": "~4.3.1",
-        "engine.io-parser": "~5.0.0",
-        "ws": "~8.2.3"
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
       },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha1-BCZuC3CpjURi5uKI44JZITMytmQ=",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-          "dev": true
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
         }
       }
     },
-    "engine.io-parser": {
-      "version": "5.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/engine.io-parser/-/engine.io-parser-5.0.2.tgz",
-      "integrity": "sha1-aaLsPtQx2gIfBmZxLQfxBrz/ps4=",
+    "node_modules/engine.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
-      "requires": {
-        "base64-arraybuffer": "~1.0.1"
+      "license": "MIT"
+    },
+    "node_modules/ent": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.2.tgz",
+      "integrity": "sha512-kKvD1tO6BM+oK9HzCPpUdRb4vKFQY/FPTFmurMvh6LlN68VMrdj77w8yp51/kDbpkFOS9J8w5W6zIzgM2H8/hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "punycode": "^1.4.1",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "ent": {
-      "version": "2.2.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ent/-/ent-2.2.0.tgz",
-      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
-      "dev": true
-    },
-    "error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha1-tKxAZIEH/c3PriQvQovqihTU8b8=",
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "is-arrayish": "^0.2.1"
       }
     },
-    "es-abstract": {
-      "version": "1.19.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/es-abstract/-/es-abstract-1.19.1.tgz",
-      "integrity": "sha1-1IhXlodpFpWd547aoN9FZicRXsM=",
+    "node_modules/es-abstract": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
+      "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
       "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.1.1",
-        "get-symbol-description": "^1.0.0",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.2",
-        "internal-slot": "^1.0.3",
-        "is-callable": "^1.2.4",
-        "is-negative-zero": "^2.0.1",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.1",
-        "is-string": "^1.0.7",
-        "is-weakref": "^1.0.1",
-        "object-inspect": "^1.11.0",
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
         "object-keys": "^1.1.1",
-        "object.assign": "^4.1.2",
-        "string.prototype.trimend": "^1.0.4",
-        "string.prototype.trimstart": "^1.0.4",
-        "unbox-primitive": "^1.0.1"
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "es-get-iterator": {
-      "version": "1.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/es-get-iterator/-/es-get-iterator-1.1.2.tgz",
-      "integrity": "sha1-kjTFSrpxNIbX694CIIZK9eKyg/c=",
+    "node_modules/es-array-method-boxes-properly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+      "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
       "dev": true,
-      "requires": {
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-get-iterator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
+      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.0",
-        "has-symbols": "^1.0.1",
-        "is-arguments": "^1.1.0",
+        "get-intrinsic": "^1.1.3",
+        "has-symbols": "^1.0.3",
+        "is-arguments": "^1.1.1",
         "is-map": "^2.0.2",
         "is-set": "^2.0.2",
-        "is-string": "^1.0.5",
-        "isarray": "^2.0.5"
+        "is-string": "^1.0.7",
+        "isarray": "^2.0.5",
+        "stop-iteration-iterator": "^1.0.0"
       },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha1-ivHkwSISRMxiRZ+vOJQNTmRKVyM=",
-          "dev": true
-        }
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "es-to-primitive": {
-      "version": "1.2.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha1-5VzUyc3BiLzvsDs2bHNjI/xciYo=",
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "dev": true,
-      "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha1-k8WjrP2+8nUiCtcmRK0C7hg2jeE=",
+    "node_modules/es-to-primitive": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+      "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
       "dev": true,
-      "requires": {
-        "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
-        "next-tick": "~1.0.0"
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.0.5",
+        "is-symbol": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "es6-iterator": {
+    "node_modules/es5-ext": {
+      "version": "0.10.64",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+      "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "ISC",
+      "dependencies": {
+        "es6-iterator": "^2.0.3",
+        "es6-symbol": "^3.1.3",
+        "esniff": "^2.0.1",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/es6-iterator": {
       "version": "2.0.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/es6-iterator/-/es6-iterator-2.0.3.tgz",
-      "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+      "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.35",
         "es6-symbol": "^3.1.1"
-      },
-      "dependencies": {
-        "d": {
-          "version": "1.0.1",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/d/-/d-1.0.1.tgz",
-          "integrity": "sha1-hpgJU3LVjb7jRv/Qxwk/mfj561o=",
-          "dev": true,
-          "requires": {
-            "es5-ext": "^0.10.50",
-            "type": "^1.0.1"
-          }
-        }
       }
     },
-    "es6-promise": {
+    "node_modules/es6-iterator/node_modules/d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/es6-promise": {
       "version": "3.3.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/es6-promise/-/es6-promise-3.3.1.tgz",
-      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
-      "dev": true
-    },
-    "es6-symbol": {
-      "version": "3.1.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/es6-symbol/-/es6-symbol-3.1.3.tgz",
-      "integrity": "sha1-utXTwbzawoJp9MszHkMceKxwXRg=",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+      "integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
       "dev": true,
-      "requires": {
-        "d": "^1.0.1",
-        "ext": "^1.1.2"
-      },
+      "license": "MIT"
+    },
+    "node_modules/es6-symbol": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
+      "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+      "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "d": {
-          "version": "1.0.1",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/d/-/d-1.0.1.tgz",
-          "integrity": "sha1-hpgJU3LVjb7jRv/Qxwk/mfj561o=",
-          "dev": true,
-          "requires": {
-            "es5-ext": "^0.10.50",
-            "type": "^1.0.1"
-          }
-        }
+        "d": "^1.0.2",
+        "ext": "^1.7.0"
+      },
+      "engines": {
+        "node": ">=0.12"
       }
     },
-    "es6-weak-map": {
-      "version": "0.1.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
-      "integrity": "sha1-cGzvnpmqI2undmwjnIueKG6n0ig=",
+    "node_modules/es6-symbol/node_modules/d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
       "dev": true,
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/es6-weak-map": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+      "integrity": "sha512-P+N5Cd2TXeb7G59euFiM7snORspgbInS29Nbf3KNO2JQp/DyhvMCDWd58nsVAXwYJ6W3Bx7qDdy6QQ3PCJ7jKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "d": "~0.1.1",
         "es5-ext": "~0.10.6",
         "es6-iterator": "~0.1.3",
         "es6-symbol": "~2.0.1"
-      },
-      "dependencies": {
-        "es6-iterator": {
-          "version": "0.1.3",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/es6-iterator/-/es6-iterator-0.1.3.tgz",
-          "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4=",
-          "dev": true,
-          "requires": {
-            "d": "~0.1.1",
-            "es5-ext": "~0.10.5",
-            "es6-symbol": "~2.0.1"
-          }
-        },
-        "es6-symbol": {
-          "version": "2.0.1",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/es6-symbol/-/es6-symbol-2.0.1.tgz",
-          "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M=",
-          "dev": true,
-          "requires": {
-            "d": "~0.1.1",
-            "es5-ext": "~0.10.5"
-          }
-        }
       }
     },
-    "escalade": {
-      "version": "3.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/escalade/-/escalade-3.1.1.tgz",
-      "integrity": "sha1-2M/ccACWXFoBdLSoLqpcBVJ0LkA=",
-      "dev": true
-    },
-    "escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-      "dev": true
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
-    },
-    "event-emitter": {
-      "version": "0.3.5",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+    "node_modules/es6-weak-map/node_modules/es6-iterator": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+      "integrity": "sha512-6TOmbFM6OPWkTe+bQ3ZuUkvqcWUjAnYjKUCLdbvRsAUz2Pr+fYIibwNXNkLNtIK9PPFbNMZZddaRNkyJhlGJhA==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
+        "d": "~0.1.1",
+        "es5-ext": "~0.10.5",
+        "es6-symbol": "~2.0.1"
+      }
+    },
+    "node_modules/es6-weak-map/node_modules/es6-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+      "integrity": "sha512-wjobO4zO8726HVU7mI2OA/B6QszqwHJuKab7gKHVx+uRfVVYGcWJkCIFxV2Madqb9/RUSrhJ/r6hPfG7FsWtow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "d": "~0.1.1",
+        "es5-ext": "~0.10.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/esniff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+      "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d": "^1.0.1",
+        "es5-ext": "^0.10.62",
+        "event-emitter": "^0.3.5",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esniff/node_modules/d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/event-emitter": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "d": "1",
         "es5-ext": "~0.10.14"
-      },
-      "dependencies": {
-        "d": {
-          "version": "1.0.1",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/d/-/d-1.0.1.tgz",
-          "integrity": "sha1-hpgJU3LVjb7jRv/Qxwk/mfj561o=",
-          "dev": true,
-          "requires": {
-            "es5-ext": "^0.10.50",
-            "type": "^1.0.1"
-          }
-        }
       }
     },
-    "eventemitter3": {
-      "version": "4.0.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha1-Lem2j2Uo1WRO9cWVJqG0oHMGFp8=",
-      "dev": true
-    },
-    "execa": {
-      "version": "0.8.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/execa/-/execa-0.8.0.tgz",
-      "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+    "node_modules/event-emitter/node_modules/d": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+      "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
       "dev": true,
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "type": "^2.7.2"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/execa": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+      "integrity": "sha512-zDWS+Rb1E8BlqqhALSt9kUhss8Qq4nN3iof3gsOdyINksElaPyNBtKUMTR62qhvgVWR0CqCX7sdnKe4MnUbFEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "cross-spawn": "^5.0.1",
         "get-stream": "^3.0.0",
         "is-stream": "^1.1.0",
@@ -1334,64 +1880,88 @@
         "p-finally": "^1.0.0",
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
-      }
-    },
-    "exit": {
-      "version": "0.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-      "dev": true
-    },
-    "ext": {
-      "version": "1.6.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ext/-/ext-1.6.0.tgz",
-      "integrity": "sha1-OHHVBkHodMwXLitT+RmELRnbTFI=",
-      "dev": true,
-      "requires": {
-        "type": "^2.5.0"
       },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/execa/node_modules/cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "type": {
-          "version": "2.5.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/type/-/type-2.5.0.tgz",
-          "integrity": "sha1-Ci54wud5B7JSq+XymMGwHGPw2z0=",
-          "dev": true
-        }
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
-    "extend": {
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/ext": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+      "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "type": "^2.7.2"
+      }
+    },
+    "node_modules/extend": {
       "version": "3.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo=",
-      "dev": true
-    },
-    "eyes": {
-      "version": "0.1.8",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
-      "dev": true
-    },
-    "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha1-GRmmp8df44ssfHflGYU12prN2kA=",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "dev": true,
-      "requires": {
-        "to-regex-range": "^5.0.1"
+      "license": "MIT"
+    },
+    "node_modules/eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha512-GipyPsXO1anza0AOZdy69Im7hGFCNB7Y/NGjDlZGJ3GJJLtwNSb2vrzYrTYJRrRloVx7pl+bhUaTB8yiccPvFQ==",
+      "dev": true,
+      "engines": {
+        "node": "> 0.1.90"
       }
     },
-    "filled-array": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/filled-array/-/filled-array-1.1.0.tgz",
-      "integrity": "sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q=",
-      "dev": true
-    },
-    "finalhandler": {
-      "version": "1.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/finalhandler/-/finalhandler-1.1.2.tgz",
-      "integrity": "sha1-t+fQAP/RGTjQ/bBTUG9uur6fWH0=",
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/filled-array": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/filled-array/-/filled-array-1.1.0.tgz",
+      "integrity": "sha512-4XwZ1k4rgoF3Yap59MyXFmiUh2zu9fht32NYPSRYwLv4o8BWHxi60I1VH5kHje14qGMoS3qyfHQUsN16ROOugQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+      "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~1.0.2",
         "escape-html": "~1.0.3",
@@ -1399,149 +1969,270 @@
         "parseurl": "~1.3.3",
         "statuses": "~1.5.0",
         "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
-    "find-up": {
-      "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha1-TJKBnstwg1YeT0okCoa+UZj1Nvw=",
+    "node_modules/finalhandler/node_modules/on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==",
       "dev": true,
-      "requires": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
-    "flatted": {
-      "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/flatted/-/flatted-2.0.2.tgz",
-      "integrity": "sha1-RXWyHivO50NKqb5mL0t7X5wrUTg=",
-      "dev": true
-    },
-    "follow-redirects": {
-      "version": "1.14.5",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/follow-redirects/-/follow-redirects-1.14.5.tgz",
-      "integrity": "sha1-8JpYSJgdPHcrU5Iwl3hSP42Fw4E=",
-      "dev": true
-    },
-    "for-each": {
-      "version": "0.3.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha1-abRH6IoKXTLD5whPPxcQA0shN24=",
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
-      "requires": {
-        "is-callable": "^1.1.3"
-      }
+      "license": "ISC"
     },
-    "foreach": {
-      "version": "2.0.5",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-      "dev": true
-    },
-    "form-data": {
-      "version": "2.5.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha1-8svsV7XlniNxbhKP5E1OXdI4lfQ=",
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "dev": true,
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
-    "fs-constants": {
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fs-constants": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0=",
-      "dev": true
-    },
-    "fs-exists-sync": {
-      "version": "0.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
-      "dev": true
-    },
-    "fs-extra": {
-      "version": "8.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/fs-extra/-/fs-extra-8.1.0.tgz",
-      "integrity": "sha1-SdQ8RaiM2Wd2aMt74bRu/bjS4cA=",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "dev": true,
-      "requires": {
+      "license": "MIT"
+    },
+    "node_modules/fs-exists-sync": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
+      "integrity": "sha512-cR/vflFyPZtrN6b38ZyWxpWdhlXrzZEBawlpBQMq7033xVY7/kg0GDMBK5jg8lDYQckdJ5x/YC88lM3C7VMsLg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
         "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
       }
     },
-    "fs.realpath": {
+    "node_modules/fs.realpath": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha1-ilJveLj99GI7cJ4Ll1xSwkwC/Ro=",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
-      "optional": true
+      "license": "ISC"
     },
-    "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0=",
-      "dev": true
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
-    "get-caller-file": {
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+      "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "functions-have-names": "^1.2.3",
+        "hasown": "^2.0.2",
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-caller-file": {
       "version": "2.0.5",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha1-T5RBKoLbMvNuOwuXQfipf+sDH34=",
-      "dev": true
-    },
-    "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha1-FfWfN2+FXERpY5SPDSTNNje0q8Y=",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
-    "get-port": {
-      "version": "3.2.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/get-port/-/get-port-3.2.0.tgz",
-      "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw=",
-      "dev": true
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "get-stdin": {
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stdin": {
       "version": "9.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/get-stdin/-/get-stdin-9.0.0.tgz",
-      "integrity": "sha1-OYP/guA9VvGy6g0+YDJfOdcDpXU=",
-      "dev": true
-    },
-    "get-stream": {
-      "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true
-    },
-    "get-symbol-description": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
-      "integrity": "sha1-f9uByQAQH71WTdXxowr1qtweWNY=",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
+      "integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==",
       "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "gl-vsts-tasks-build-scripts": {
-      "version": "0.6.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/gl-vsts-tasks-build-scripts/-/gl-vsts-tasks-build-scripts-0.6.0.tgz",
-      "integrity": "sha1-RK+0GyuqfVA45bCI6fCY+lNKLsY=",
+    "node_modules/get-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+      "integrity": "sha512-GlhdIUuVakc8SJ6kK0zAFbiGzRFzNnY4jUuEbV9UROo4Y+0Ny4fjvcZFVTeDA4odpFyOQzaw6hXukJSq/f28sQ==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gl-vsts-tasks-build-scripts": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/gl-vsts-tasks-build-scripts/-/gl-vsts-tasks-build-scripts-0.6.0.tgz",
+      "integrity": "sha512-ec9W/ZAYpSF+VUZfBXgOUtU2Cscs0CXvzXkrOHyv9xhaCZh5zoanfMXHkgaMDQIeR1bv8M9oly+DTt/7VfXp1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "async": "^3.2.0",
         "fs-extra": "8.1.0",
         "glob": "7.1.6",
@@ -1551,39 +2242,103 @@
         "semver": "7.1.3",
         "tfx-cli": "0.7.11",
         "tsconfig-glob": "^0.4.3"
+      },
+      "bin": {
+        "vsts-build-tools-clean": "run/vsts-build-tools-clean",
+        "vsts-build-tools-install": "run/vsts-build-tools-install",
+        "vsts-build-tools-node-modclean": "run/vsts-build-tools-node-modclean",
+        "vsts-build-tools-package": "run/vsts-build-tools-package",
+        "vsts-build-tools-prebuild": "run/vsts-build-tools-prebuild"
       }
     },
-    "glob": {
-      "version": "7.1.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/glob/-/glob-7.1.6.tgz",
-      "integrity": "sha1-FB8zuBp8JJLhJVlDB0gMRmeSeKY=",
+    "node_modules/gl-vsts-tasks-build-scripts/node_modules/semver": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
+      "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA==",
       "dev": true,
-      "requires": {
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
         "inherits": "2",
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "glob-parent": {
+    "node_modules/glob-parent": {
       "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha1-hpgyxYA0/mikCTwX3BXoNA2EAcQ=",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
-    "got": {
-      "version": "5.7.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/got/-/got-5.7.1.tgz",
-      "integrity": "sha1-X4FjWmHkplifGAVp6k44FoClHzU=",
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-5.6.0.tgz",
+      "integrity": "sha512-MnypzkaW8dldA8AbJFjMs7y14+ykd2V8JCLKSvX1Gmzx1alH3Y+3LArywHDoAF2wS3pnZp4gacoYtvqBeF6drQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "create-error-class": "^3.0.1",
         "duplexer2": "^0.1.4",
+        "is-plain-obj": "^1.0.0",
         "is-redirect": "^1.0.0",
         "is-retry-allowed": "^1.0.0",
         "is-stream": "^1.0.0",
@@ -1594,597 +2349,998 @@
         "pinkie-promise": "^2.0.0",
         "read-all-stream": "^3.0.0",
         "readable-stream": "^2.0.5",
-        "timed-out": "^3.0.0",
-        "unzip-response": "^1.0.2",
+        "timed-out": "^2.0.0",
+        "unzip-response": "^1.0.0",
         "url-parse-lax": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "graceful-fs": {
-      "version": "4.2.8",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/graceful-fs/-/graceful-fs-4.2.8.tgz",
-      "integrity": "sha1-5BK40z9eAGWTy9PO5t+fLOu+gCo=",
-      "dev": true
-    },
-    "hard-rejection": {
-      "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/hard-rejection/-/hard-rejection-2.1.0.tgz",
-      "integrity": "sha1-HG7aXBaFxjlCdm15u0Cudzzs2IM=",
-      "dev": true
-    },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/has/-/has-1.0.3.tgz",
-      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+    "node_modules/got/node_modules/parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
       "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
+      "license": "MIT",
+      "dependencies": {
+        "error-ex": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "has-ansi": {
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-ansi": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "has-bigints": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/has-bigints/-/has-bigints-1.0.1.tgz",
-      "integrity": "sha1-ZP5qywIGc+O3jbA1pa9pqp0HsRM=",
-      "dev": true
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "has-flag": {
+    "node_modules/has-flag": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "has-symbols": {
+    "node_modules/has-property-descriptors": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/has-symbols/-/has-symbols-1.0.2.tgz",
-      "integrity": "sha1-Fl0wcMADCXUqEjakeTMeOsVvFCM=",
-      "dev": true
-    },
-    "has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha1-fhM4GKfTlHNPlB5zw9P5KR5liyU=",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
       "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.2"
-      }
-    },
-    "hosted-git-info": {
-      "version": "4.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
-      "integrity": "sha1-XkJVB+7eT+qEa3Ji8IOEVsQgmWE=",
-      "dev": true,
-      "requires": {
-        "lru-cache": "^6.0.0"
-      },
+      "license": "MIT",
       "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
-          "dev": true
-        }
-      }
-    },
-    "http-basic": {
-      "version": "8.1.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/http-basic/-/http-basic-8.1.3.tgz",
-      "integrity": "sha1-p8q+51Joabm3EBNpcIBbEAQmG78=",
-      "dev": true,
-      "requires": {
-        "caseless": "^0.12.0",
-        "concat-stream": "^1.6.2",
-        "http-response-object": "^3.0.1",
-        "parse-cache-control": "^1.0.1"
-      }
-    },
-    "http-errors": {
-      "version": "1.7.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/http-errors/-/http-errors-1.7.2.tgz",
-      "integrity": "sha1-T1ApzxMjnzEDblsuVSkrz7zIXI8=",
-      "dev": true,
-      "requires": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.1.1",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.0"
+        "es-define-property": "^1.0.0"
       },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.3",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
-        }
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "http-proxy": {
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-proxy": {
       "version": "1.18.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/http-proxy/-/http-proxy-1.18.1.tgz",
-      "integrity": "sha1-QBVB8FNIhLv5UmAzTnL4juOXZUk=",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "eventemitter3": "^4.0.0",
         "follow-redirects": "^1.0.0",
         "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
-    "http-response-object": {
-      "version": "3.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/http-response-object/-/http-response-object-3.0.2.tgz",
-      "integrity": "sha1-f0NbshBFTkNg0HTvH5idXqiqmBA=",
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dev": true,
-      "requires": {
-        "@types/node": "^10.0.3"
-      },
+      "license": "MIT",
       "dependencies": {
-        "@types/node": {
-          "version": "10.17.60",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/node/-/node-10.17.60.tgz",
-          "integrity": "sha1-NfPWIT2u2V2n8Pc+dbzGmA6QWXs=",
-          "dev": true
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
         }
       }
     },
-    "i": {
-      "version": "0.3.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/i/-/i-0.3.7.tgz",
-      "integrity": "sha1-KnQ3qSPVnBSxckPcY6VJryTYV5k=",
-      "dev": true
-    },
-    "iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha1-ICK0sl+93CHS9SSXSkdKr+czkIs=",
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
-      "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+      "license": "MIT"
+    },
+    "node_modules/i": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.7.tgz",
+      "integrity": "sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4"
       }
     },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha1-jrehCmP/8l0VpXsAFYbRd9Gw01I=",
-      "dev": true
-    },
-    "immediate": {
-      "version": "3.0.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
-      "dev": true
-    },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
-    },
-    "indent-string": {
-      "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/indent-string/-/indent-string-5.0.0.tgz",
-      "integrity": "sha1-T9KYD8yvhiLRTGTWlPTPM8gZUaU=",
-      "dev": true
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
       }
     },
-    "inherits": {
+    "node_modules/inherits": {
       "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha1-D6LGT5MpF8NDOg3tVTY6rjdBa3w=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
     },
-    "ini": {
+    "node_modules/ini": {
       "version": "1.3.8",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha1-op2kJbSIBvNHZ6Tvzjlyaa8oQyw=",
-      "dev": true
-    },
-    "internal-slot": {
-      "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/internal-slot/-/internal-slot-1.0.3.tgz",
-      "integrity": "sha1-c0fjB97uovqsKsYgXUvH00ln9Zw=",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
-      "requires": {
-        "get-intrinsic": "^1.1.0",
-        "has": "^1.0.3",
-        "side-channel": "^1.0.4"
+      "license": "ISC"
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "interpret": {
+    "node_modules/interpret": {
       "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha1-Zlq4vE2iendKQFhOgS4+D6RbGh4=",
-      "dev": true
-    },
-    "is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha1-FbP4j9oB8ql/7ITKdhpWDxI++ps=",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-      "dev": true
-    },
-    "is-bigint": {
-      "version": "1.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-bigint/-/is-bigint-1.0.4.tgz",
-      "integrity": "sha1-CBR6GHW8KzIAXUHM2Ckd/8ZpHfM=",
-      "dev": true,
-      "requires": {
-        "has-bigints": "^1.0.1"
-      }
-    },
-    "is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha1-6h9/O4DwZCNug0cPhsCcJU+0Wwk=",
-      "dev": true,
-      "requires": {
-        "binary-extensions": "^2.0.0"
-      }
-    },
-    "is-boolean-object": {
-      "version": "1.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-      "integrity": "sha1-XG3CACRt2TIa5LiFoRS7H3X2Nxk=",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "is-callable": {
-      "version": "1.2.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-callable/-/is-callable-1.2.4.tgz",
-      "integrity": "sha1-RzAdWN0CWUB4ZVR4U99tYf5HGUU=",
-      "dev": true
-    },
-    "is-core-module": {
-      "version": "2.8.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-core-module/-/is-core-module-2.8.0.tgz",
-      "integrity": "sha1-AyEzbD0JJeSX/Zf12VyxFKXM1Ug=",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.3"
-      }
-    },
-    "is-date-object": {
-      "version": "1.0.5",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-date-object/-/is-date-object-1.0.5.tgz",
-      "integrity": "sha1-CEHVU25yTCVZe/bqYuG9OCmN8x8=",
-      "dev": true,
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true
-    },
-    "is-finite": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-finite/-/is-finite-1.1.0.tgz",
-      "integrity": "sha1-kEE1x3+0LAZB1qobzbxNqo2ggvM=",
-      "dev": true
-    },
-    "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "^1.0.0"
-      }
-    },
-    "is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha1-ZPYeQsu7LuwgcanawLKLoeZdUIQ=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "^2.1.1"
-      }
-    },
-    "is-map": {
-      "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-map/-/is-map-2.0.2.tgz",
-      "integrity": "sha1-AJItuMm/c+gbejNYJ7wqQ/K5ESc=",
-      "dev": true
-    },
-    "is-negative-zero": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
-      "integrity": "sha1-PedGwY3aIxkkGlNnWQjY92bxHCQ=",
-      "dev": true
-    },
-    "is-npm": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-npm/-/is-npm-1.0.0.tgz",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
-      "dev": true
-    },
-    "is-number": {
-      "version": "7.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha1-dTU0W4lnNNX4DE0GxQlVUnoU8Ss=",
-      "dev": true
-    },
-    "is-number-object": {
-      "version": "1.0.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-number-object/-/is-number-object-1.0.6.tgz",
-      "integrity": "sha1-anqvg4x/BoalC0VT9+VKlklOifA=",
-      "dev": true,
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "is-obj": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-      "dev": true
-    },
-    "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
-      "dev": true
-    },
-    "is-redirect": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
-      "dev": true
-    },
-    "is-regex": {
-      "version": "1.1.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-regex/-/is-regex-1.1.4.tgz",
-      "integrity": "sha1-7vVmPNWfpMCuM5UFMj32hUuxWVg=",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "is-retry-allowed": {
+    "node_modules/is-arguments": {
       "version": "1.2.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha1-13hIi9CkZmo76KFIK58rqv7eqLQ=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "is-set": {
-      "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-set/-/is-set-2.0.2.tgz",
-      "integrity": "sha1-kHVfpMJWLcHF1AJHYNYRm5TKGOw=",
-      "dev": true
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "is-shared-array-buffer": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-      "integrity": "sha1-l7DIX72stZycRG/mU7gs8rW3z+Y=",
-      "dev": true
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
     },
-    "is-stream": {
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
       "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
-    },
-    "is-string": {
-      "version": "1.0.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-string/-/is-string-1.0.7.tgz",
-      "integrity": "sha1-DdEr8gBvJVu1j2lREO/3SR7rwP0=",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
       "dev": true,
-      "requires": {
-        "has-tostringtag": "^1.0.0"
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "is-symbol": {
-      "version": "1.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-symbol/-/is-symbol-1.0.4.tgz",
-      "integrity": "sha1-ptrJO2NbBjymhyI23oiRClevE5w=",
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.2"
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
-    "is-typed-array": {
-      "version": "1.1.8",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-typed-array/-/is-typed-array-1.1.8.tgz",
-      "integrity": "sha1-y6plhdx9tDMYvFuJUj6jhKb2Xnk=",
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
       "dev": true,
-      "requires": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "es-abstract": "^1.18.5",
-        "foreach": "^2.0.5",
-        "has-tostringtag": "^1.0.0"
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "is-weakmap": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-weakmap/-/is-weakmap-2.0.1.tgz",
-      "integrity": "sha1-UAi1m9xDtpggHRj2KzeyyiQ+jPI=",
-      "dev": true
-    },
-    "is-weakref": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-weakref/-/is-weakref-1.0.1.tgz",
-      "integrity": "sha1-hC26TsF/qayYUN8tbvvBc3J08qI=",
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
       "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0"
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "is-weakset": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-weakset/-/is-weakset-2.0.1.tgz",
-      "integrity": "sha1-6aCviNvXUVifXlDYD0yYt4CIT4M=",
-      "dev": true
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
-    "isarray": {
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-finite": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
+      "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
-    },
-    "isbinaryfile": {
-      "version": "4.0.8",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/isbinaryfile/-/isbinaryfile-4.0.8.tgz",
-      "integrity": "sha1-XTS5SGW9SUZjPsx4oCb8dsWxH88=",
-      "dev": true
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
-    },
-    "jju": {
-      "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/jju/-/jju-1.4.0.tgz",
-      "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
-      "dev": true
-    },
-    "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk=",
-      "dev": true
-    },
-    "json-in-place": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/json-in-place/-/json-in-place-1.0.1.tgz",
-      "integrity": "sha1-ih7NJaac4ZAFUs1xUr2TdU3k4fA=",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-npm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
+      "integrity": "sha512-9r39FIr3d+KD9SbX0sfMsHzb5PP3uimOiwr3YupUaUFG4W0l1U57Rx3utpttV7qz5U3jmrO5auUa04LU9pyHsg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-redirect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha512-cr/SlUEe5zOGmzvj9bUyC4LVvkNVAXu4GytXLNMr1pny+a65MpQ9IJzFHD5vi7FyJgb4qt27+eS3TuQnqB+RQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isbinaryfile": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+      "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jju": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-in-place": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-in-place/-/json-in-place-1.0.1.tgz",
+      "integrity": "sha512-XDFWT1iOlZErTFU0GGRju9g/uzY8BVFVsGsbgiE71Fg2+3c0lK4X4GSRB8PQ527hVkAJ2Z5Qv2sa7Re9iFNYKw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
         "json-lexer": "1.1.1"
       }
     },
-    "json-lexer": {
+    "node_modules/json-lexer": {
       "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/json-lexer/-/json-lexer-1.1.1.tgz",
-      "integrity": "sha1-vT7V1+Vgudma0iNPKMpwb7N3t9Q=",
-      "dev": true
-    },
-    "json-parse-better-errors": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha1-u4Z8+zRQ5pEHwTHRxRS6s9yLyqk=",
-      "dev": true
-    },
-    "json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha1-fEeAWpQxmSjgV3dAXcEuH3pO4C0=",
-      "dev": true
-    },
-    "jsonfile": {
-      "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "resolved": "https://registry.npmjs.org/json-lexer/-/json-lexer-1.1.1.tgz",
+      "integrity": "sha512-kdpvcH1gqYXQEAVFxVwIWZKihrS0o9SjbwW2v8+0p6HA/YSMk5c4BkXdMiz/kDz2QW0XlOSkFKrJsC9KL0Mb5g==",
       "dev": true,
-      "requires": {
+      "license": "ISC"
+    },
+    "node_modules/json-parse-better-errors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
+      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
     },
-    "jszip": {
+    "node_modules/jszip": {
       "version": "3.1.5",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/jszip/-/jszip-3.1.5.tgz",
-      "integrity": "sha1-48KmxtcGrG5gMxQDbUPNQL7v3zc=",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
+      "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
       "dev": true,
-      "requires": {
+      "license": "(MIT OR GPL-3.0)",
+      "dependencies": {
         "core-js": "~2.3.0",
         "es6-promise": "~3.0.2",
         "lie": "~3.1.0",
         "pako": "~1.0.2",
         "readable-stream": "~2.0.6"
-      },
-      "dependencies": {
-        "es6-promise": {
-          "version": "3.0.2",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/es6-promise/-/es6-promise-3.0.2.tgz",
-          "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y=",
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "2.0.6",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/readable-stream/-/readable-stream-2.0.6.tgz",
-          "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~1.0.6",
-            "string_decoder": "~0.10.x",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
       }
     },
-    "karma": {
-      "version": "6.3.9",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/karma/-/karma-6.3.9.tgz",
-      "integrity": "sha1-zDCWB/D821iohkMYTz5LqL/yZ1E=",
+    "node_modules/jszip/node_modules/es6-promise": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+      "integrity": "sha512-CUD62/uqeE0L+EJeypOKuFfM56CFaH4vo+++J76bff0NkeQ2bBmWVCTNxL2hj9HeCYPkof6Gqea0BSeK17gBzA==",
       "dev": true,
-      "requires": {
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha512-yN0WQmuCX63LP/TMvAg31nvT6m4vDqJEiiv2CAZqWOGNWutc9DfDk1NPYYmKUFmaVM2UwDowH4u5AHWYP/jxKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
+      "integrity": "sha512-TXcFfb63BQe1+ySzsHZI/5v1aJPCShfqvWJ64ayNImXMsN1Cd0YGk/wm8KB7/OeessgPc9QvS9Zou8QTkFzsLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~0.10.x",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/karma": {
+      "version": "6.4.4",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.4.4.tgz",
+      "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
         "braces": "^3.0.2",
         "chokidar": "^3.5.1",
-        "colors": "^1.4.0",
         "connect": "^3.7.0",
         "di": "^0.0.1",
         "dom-serialize": "^2.2.1",
@@ -2193,228 +3349,244 @@
         "http-proxy": "^1.18.1",
         "isbinaryfile": "^4.0.8",
         "lodash": "^4.17.21",
-        "log4js": "^6.3.0",
+        "log4js": "^6.4.1",
         "mime": "^2.5.2",
         "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.5",
         "qjobs": "^1.2.0",
         "range-parser": "^1.2.1",
         "rimraf": "^3.0.2",
-        "socket.io": "^4.2.0",
+        "socket.io": "^4.7.2",
         "source-map": "^0.6.1",
         "tmp": "^0.2.1",
         "ua-parser-js": "^0.7.30",
         "yargs": "^16.1.1"
       },
+      "bin": {
+        "karma": "bin/karma"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/karma/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "colors": {
-          "version": "1.4.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/colors/-/colors-1.4.0.tgz",
-          "integrity": "sha1-xQSRR51MG9rtLJztMs98fcI2D3g=",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.2.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/glob/-/glob-7.2.0.tgz",
-          "integrity": "sha1-0VU1r3cy4C6Uj0xBYovZECk/YCM=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.21",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/lodash/-/lodash-4.17.21.tgz",
-          "integrity": "sha1-Z5WRxWTDv/quhFTPCz3zcMPWkRw=",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "3.0.2",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/rimraf/-/rimraf-3.0.2.tgz",
-          "integrity": "sha1-8aVAK6YiCtUswSgrrBrjqkn9Bho=",
-          "dev": true,
-          "requires": {
-            "glob": "^7.1.3"
-          }
-        },
-        "tmp": {
-          "version": "0.2.1",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/tmp/-/tmp-0.2.1.tgz",
-          "integrity": "sha1-hFf8MDfc9HGcJRNnoa9lAO4czxQ=",
-          "dev": true,
-          "requires": {
-            "rimraf": "^3.0.0"
-          }
-        }
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "kind-of": {
-      "version": "6.0.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/kind-of/-/kind-of-6.0.3.tgz",
-      "integrity": "sha1-B8BQNKbDSfoG4k+jWqdttFgM5N0=",
-      "dev": true
+    "node_modules/karma/node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
     },
-    "latest-version": {
+    "node_modules/karma/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/latest-version": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/latest-version/-/latest-version-2.0.0.tgz",
-      "integrity": "sha1-VvjWE5YghHuAF/jx9NeOIRMkFos=",
+      "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-2.0.0.tgz",
+      "integrity": "sha512-8925wFYLfWBciewimt0VmDyYw0GFCRcbFSTrZGt4JgQ7lh5jb/kodMlUt0uMaxXdRKVi+7F3ib30N7fTv83ikw==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "package-json": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "lazy-req": {
+    "node_modules/lazy-req": {
       "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/lazy-req/-/lazy-req-1.1.0.tgz",
-      "integrity": "sha1-va6+rTD42CQDnODOFJ1Nqge6H6w=",
-      "dev": true
-    },
-    "lazystream": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/lazystream/-/lazystream-1.0.1.tgz",
-      "integrity": "sha1-SUyDEGLx+UCCUexE2xy6KSQqJjg=",
+      "resolved": "https://registry.npmjs.org/lazy-req/-/lazy-req-1.1.0.tgz",
+      "integrity": "sha512-Vn/JuGaYykbelAVNAhfVJxuwHQCOSNE6mqMtD+gnd+QORlAHwWVmVFqQga3yWt84G5vAwEwpT6sAsZ+tgJ88/Q==",
       "dev": true,
-      "requires": {
-        "readable-stream": "^2.0.5"
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "lie": {
-      "version": "3.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/lie/-/lie-3.1.1.tgz",
-      "integrity": "sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=",
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "immediate": "~3.0.5"
       }
     },
-    "lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha1-7KKE910pZQeTCdwK2SVauy68FjI=",
-      "dev": true
-    },
-    "load-json-file": {
+    "node_modules/load-json-file": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/load-json-file/-/load-json-file-4.0.0.tgz",
-      "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+      "integrity": "sha512-Kx8hMakjX03tiGTLAIdJ+lL0htKnXjEZN6hk/tozf/WOuYGdZBJrZ+rCJRbVCugsjB3jMLn9746NsQIf5VjBMw==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "graceful-fs": "^4.1.2",
         "parse-json": "^4.0.0",
         "pify": "^3.0.0",
         "strip-bom": "^3.0.0"
       },
-      "dependencies": {
-        "parse-json": {
-          "version": "4.0.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/parse-json/-/parse-json-4.0.0.tgz",
-          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.3.1",
-            "json-parse-better-errors": "^1.0.1"
-          }
-        }
+      "engines": {
+        "node": ">=4"
       }
     },
-    "locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha1-VTIeswn+u8WcSAHZMackUqaB0oY=",
-      "dev": true,
-      "requires": {
-        "p-locate": "^5.0.0"
-      }
-    },
-    "lodash": {
+    "node_modules/lodash": {
       "version": "4.17.15",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha1-tEf2ZwoEVbv+7dETku/zMOoJdUg=",
-      "dev": true
-    },
-    "lodash.uniq": {
-      "version": "4.5.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
-      "dev": true
-    },
-    "log4js": {
-      "version": "6.3.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/log4js/-/log4js-6.3.0.tgz",
-      "integrity": "sha1-EN+vu0NDUaPjAnegC5h5RG9xW8s=",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
       "dev": true,
-      "requires": {
-        "date-format": "^3.0.0",
-        "debug": "^4.1.1",
-        "flatted": "^2.0.1",
-        "rfdc": "^1.1.4",
-        "streamroller": "^2.2.4"
-      },
+      "license": "MIT"
+    },
+    "node_modules/lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log4js": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.9.1.tgz",
+      "integrity": "sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==",
+      "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha1-BCZuC3CpjURi5uKI44JZITMytmQ=",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-          "dev": true
+        "date-format": "^4.0.14",
+        "debug": "^4.3.4",
+        "flatted": "^3.2.7",
+        "rfdc": "^1.3.0",
+        "streamroller": "^3.1.5"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/log4js/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
         }
       }
     },
-    "lowercase-keys": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
-      "dev": true
-    },
-    "lru-cache": {
-      "version": "4.1.5",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/lru-cache/-/lru-cache-4.1.5.tgz",
-      "integrity": "sha1-i75Q6oW+1ZvJ4z3KuCNe6bz0Q80=",
+    "node_modules/log4js/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
-      "requires": {
+      "license": "MIT"
+    },
+    "node_modules/lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
     },
-    "lru-queue": {
+    "node_modules/lru-queue": {
       "version": "0.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/lru-queue/-/lru-queue-0.1.0.tgz",
-      "integrity": "sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=",
+      "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+      "integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "es5-ext": "~0.10.2"
       }
     },
-    "map-obj": {
-      "version": "4.3.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/map-obj/-/map-obj-4.3.0.tgz",
-      "integrity": "sha1-kwT5Buk/qucIgNoQKp8d8OqLsFo=",
-      "dev": true
-    },
-    "media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-      "dev": true
-    },
-    "memoizee": {
-      "version": "0.3.10",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/memoizee/-/memoizee-0.3.10.tgz",
-      "integrity": "sha1-TsoNiu057J0Bf0xcLy9kMvQuXI8=",
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/memoizee": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.10.tgz",
+      "integrity": "sha512-LLzVUuWwGBKK188spgOK/ukrp5zvd9JGsiLDH41pH9vt5jvhZfsu5pxDuAnYAMG8YEGce72KO07sSBy9KkvOfw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "d": "~0.1.1",
         "es5-ext": "~0.10.11",
         "es6-weak-map": "~0.1.4",
@@ -2422,124 +3594,123 @@
         "lru-queue": "0.1",
         "next-tick": "~0.2.2",
         "timers-ext": "0.1"
-      },
-      "dependencies": {
-        "next-tick": {
-          "version": "0.2.2",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/next-tick/-/next-tick-0.2.2.tgz",
-          "integrity": "sha1-ddpKkn7liH45BliABltzNkE7MQ0=",
-          "dev": true
-        }
       }
     },
-    "memorystream": {
+    "node_modules/memoizee/node_modules/next-tick": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
+      "integrity": "sha512-f7h4svPtl+QidoBv4taKXUjJ70G2asaZ8G28nS0OkqaalX8dwwrtWtyxEDPK62AC00ur/+/E0pUwBwY5EPn15Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/memorystream": {
       "version": "0.3.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/memorystream/-/memorystream-0.3.1.tgz",
-      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
-      "dev": true
-    },
-    "meow": {
-      "version": "10.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/meow/-/meow-10.1.2.tgz",
-      "integrity": "sha1-YpUctpr6aVlBQsglCAa8MKORLk0=",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
+      "integrity": "sha512-S3UwM3yj5mtUSEfP41UZmt/0SCoVYUcU1rkXv+BQ5Ig8ndL4sPoJNBUJERafdPb5jjHJGuMgytgKvKIf58XNBw==",
       "dev": true,
-      "requires": {
-        "@types/minimist": "^1.2.2",
-        "camelcase-keys": "^7.0.0",
-        "decamelize": "^5.0.0",
-        "decamelize-keys": "^1.1.0",
-        "hard-rejection": "^2.1.0",
-        "minimist-options": "4.1.0",
-        "normalize-package-data": "^3.0.2",
-        "read-pkg-up": "^8.0.0",
-        "redent": "^4.0.0",
-        "trim-newlines": "^4.0.2",
-        "type-fest": "^1.2.2",
-        "yargs-parser": "^20.2.9"
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
-    "mime": {
-      "version": "2.6.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha1-oqaCqVzU0MsdYlfij4PafjWAA2c=",
-      "dev": true
-    },
-    "mime-db": {
-      "version": "1.51.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha1-2f9iRRhZsYNC2WCFDcPPt35j+ww=",
-      "dev": true
-    },
-    "mime-types": {
-      "version": "2.1.34",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/mime-types/-/mime-types-2.1.34.tgz",
-      "integrity": "sha1-WnEvnsFQNRGpRYA2QPr+CdN5PCQ=",
+    "node_modules/meow": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-14.0.0.tgz",
+      "integrity": "sha512-JhC3R1f6dbspVtmF3vKjAWz1EVIvwFrGGPLSdU6rK79xBwHWTuHoLnRX/t1/zHS1Ch1Y2UtIrih7DAHuH9JFJA==",
       "dev": true,
-      "requires": {
-        "mime-db": "1.51.0"
-      }
-    },
-    "min-indent": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/min-indent/-/min-indent-1.0.1.tgz",
-      "integrity": "sha1-pj9oFnOzBXH76LwlaGrnRu76mGk=",
-      "dev": true
-    },
-    "minimatch": {
-      "version": "3.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
-    },
-    "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-      "dev": true
-    },
-    "minimist-options": {
-      "version": "4.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/minimist-options/-/minimist-options-4.1.0.tgz",
-      "integrity": "sha1-wGVXE8U6ii69d/+iR9NCxA8BBhk=",
-      "dev": true,
-      "requires": {
-        "arrify": "^1.0.1",
-        "is-plain-obj": "^1.1.0",
-        "kind-of": "^6.0.3"
-      }
-    },
-    "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha1-2Rzv1i0UNsoPQWIOJRKI1CAJne8=",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha1-Z9ZgFLZqaoqqDAg8X9WN9OTpdgI=",
-          "dev": true
-        }
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "mockery": {
-      "version": "1.7.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/mockery/-/mockery-1.7.0.tgz",
-      "integrity": "sha1-9O3g2HUMHJcnwnLqLGBiniyaHE8=",
-      "dev": true
-    },
-    "modclean": {
-      "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/modclean/-/modclean-2.1.0.tgz",
-      "integrity": "sha1-pDFvPJe/RxHmglFQDK5ShVII5Js=",
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha512-7Wl+Jz+IGWuSdgsQEJ4JunV0si/iMhg42MnQQG6h1R6TNeVenp4U9x5CC5v/gYqz/fENLQITAWXidNtVL0NNbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/mkdirp/node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/modclean": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/modclean/-/modclean-2.1.0.tgz",
+      "integrity": "sha512-/+t2vu/BBqvJC1SPWcp4aBKQqx4deveZYzlTsIjREZmZmjpM7rpd8R/n6foRx95nWQkPJxT5fBiTvJG2kGHfNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "async-each-series": "^1.1.0",
         "chalk": "^1.1.3",
         "clui": "^0.3.1",
@@ -2551,109 +3722,136 @@
         "rimraf": "^2.5.4",
         "subdirs": "^1.0.0",
         "update-notifier": "^1.0.3"
-      }
-    },
-    "modclean-patterns-default": {
-      "version": "1.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/modclean-patterns-default/-/modclean-patterns-default-1.1.2.tgz",
-      "integrity": "sha1-my1T46vXB+3PDBUBtNWsBMlHooM=",
-      "dev": true
-    },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
-    },
-    "mute-stream": {
-      "version": "0.0.8",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/mute-stream/-/mute-stream-0.0.8.tgz",
-      "integrity": "sha1-FjDEKyJR/4HiooPelqVJfqkuXg0=",
-      "dev": true
-    },
-    "ncp": {
-      "version": "0.4.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ncp/-/ncp-0.4.2.tgz",
-      "integrity": "sha1-q8xsvT7C7Spyn/bnwfqPAXhKhXQ=",
-      "dev": true
-    },
-    "negotiator": {
-      "version": "0.6.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/negotiator/-/negotiator-0.6.2.tgz",
-      "integrity": "sha1-/qz3zPUlp3rpY0Q2pkiD/+yjRvs=",
-      "dev": true
-    },
-    "next-tick": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/next-tick/-/next-tick-1.0.0.tgz",
-      "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
-      "dev": true
-    },
-    "nice-try": {
-      "version": "1.0.5",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha1-ozeKdpbOfSI+iPybdkvX7xCJ42Y=",
-      "dev": true
-    },
-    "node-status-codes": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/node-status-codes/-/node-status-codes-1.0.0.tgz",
-      "integrity": "sha1-WuVUHQJGRdMqWPzdyc7s6nrjrC8=",
-      "dev": true
-    },
-    "normalize-package-data": {
-      "version": "3.0.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-      "integrity": "sha1-28w+LaWVCaCYNCKITNFy7v36Ul4=",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "^4.0.1",
-        "is-core-module": "^2.5.0",
-        "semver": "^7.3.4",
-        "validate-npm-package-license": "^3.0.1"
       },
+      "bin": {
+        "modclean": "bin/modclean.js"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/modclean-patterns-default": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/modclean-patterns-default/-/modclean-patterns-default-1.1.2.tgz",
+      "integrity": "sha512-h2+ES3SKl+JOtfptJjwJz5fdogFI0byYssw3lXoESNkOcXCnjCvvW6IbMagAKFmfWOx+n9esyomxWP1w4edZjg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/modclean/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha1-C2Ich5NI2JmOSw5L6Us/EuYBjvc=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
-          "dev": true
-        }
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       }
     },
-    "normalize-path": {
-      "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/normalize-path/-/normalize-path-2.1.1.tgz",
-      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true,
-      "requires": {
-        "remove-trailing-separator": "^1.0.1"
+      "license": "MIT"
+    },
+    "node_modules/mute-stream": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+      "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ncp": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz",
+      "integrity": "sha512-PfGU8jYWdRl4FqJfCy0IzbkGyFHntfWygZg46nFk/dJD/XRrk2cj0SsKSX9n5u5gE0E0YfEpKWrEkfjnlZSTXA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "ncp": "bin/ncp"
       }
     },
-    "npm-run-all": {
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/next-tick": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+      "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/node-status-codes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
+      "integrity": "sha512-1cBMgRxdMWE8KeWCqk2RIOrvUb0XCwYfEsY5/y2NlXyq4Y/RumnOZvTj4Nbr77+Vb2C+kyBoRTdkNOS8L3d/aQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nodejs-file-downloader": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/nodejs-file-downloader/-/nodejs-file-downloader-4.13.0.tgz",
+      "integrity": "sha512-nI2fKnmJWWFZF6SgMPe1iBodKhfpztLKJTtCtNYGhm/9QXmWa/Pk9Sv00qHgzEvNLe1x7hjGDRor7gcm/ChaIQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "https-proxy-agent": "^5.0.0",
+        "mime-types": "^2.1.27",
+        "sanitize-filename": "^1.6.3"
+      }
+    },
+    "node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-run-all": {
       "version": "4.1.5",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/npm-run-all/-/npm-run-all-4.1.5.tgz",
-      "integrity": "sha1-BEdiAqFe4OLiFAgIYb/xKlHZj7o=",
+      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
+      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "ansi-styles": "^3.2.1",
         "chalk": "^2.4.1",
         "cross-spawn": "^6.0.5",
@@ -2664,497 +3862,606 @@
         "shell-quote": "^1.6.1",
         "string.prototype.padend": "^3.0.0"
       },
+      "bin": {
+        "npm-run-all": "bin/npm-run-all/index.js",
+        "run-p": "bin/run-p/index.js",
+        "run-s": "bin/run-s/index.js"
+      },
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha1-zUJUFnelQzPPVBpJEIwUMrRMlCQ=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "cross-spawn": {
-          "version": "6.0.5",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/cross-spawn/-/cross-spawn-6.0.5.tgz",
-          "integrity": "sha1-Sl7Hxk364iw6FBJNus3uhG2Ay8Q=",
-          "dev": true,
-          "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
-          }
-        },
-        "hosted-git-info": {
-          "version": "2.8.9",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-          "integrity": "sha1-3/wL+aIcAiCQkPKqaUKeFBTa8/k=",
-          "dev": true
-        },
-        "normalize-package-data": {
-          "version": "2.5.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-          "integrity": "sha1-5m2xg4sgDB38IzIl0SyzZSDiNKg=",
-          "dev": true,
-          "requires": {
-            "hosted-git-info": "^2.1.4",
-            "resolve": "^1.10.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
-          }
-        },
-        "read-pkg": {
-          "version": "3.0.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/read-pkg/-/read-pkg-3.0.0.tgz",
-          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^4.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^3.0.0"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha1-4uaaRKyHcveKHsCzW2id9lMO/I8=",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "npm-run-path": {
+    "node_modules/npm-run-all/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-all/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/npm-run-path": {
       "version": "2.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "path-key": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "number-is-nan": {
+    "node_modules/number-is-nan": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "object-assign": {
+    "node_modules/object-assign": {
       "version": "4.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
-    },
-    "object-inspect": {
-      "version": "1.11.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/object-inspect/-/object-inspect-1.11.0.tgz",
-      "integrity": "sha1-nc6xRs7dQUig2eUauI00z1CZIrE=",
-      "dev": true
-    },
-    "object-is": {
-      "version": "1.1.5",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/object-is/-/object-is-1.1.5.tgz",
-      "integrity": "sha1-ud7qpfx/GEag+uzc7sE45XePU6w=",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "object-keys": {
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-is": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.6.tgz",
+      "integrity": "sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
       "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha1-HEfyct8nfzsdrwYWd9nILiMixg4=",
-      "dev": true
-    },
-    "object.assign": {
-      "version": "4.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha1-DtVKNC7Os3s4/3brgxoOeIy2OUA=",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
       "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
         "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "object.getownpropertydescriptors": {
-      "version": "2.1.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.3.tgz",
-      "integrity": "sha1-siPPOOF/77l6Y8EMkd9yzLOG354=",
+    "node_modules/object.getownpropertydescriptors": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.8.tgz",
+      "integrity": "sha512-qkHIGe4q0lSYMv0XI4SsBTJz3WaURhLvd0lKSgtVuOsJ2krg4SgMw3PIRQFMp07yi++UR3se2mkcLqsBNpBb/A==",
       "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.reduce": "^1.0.6",
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0",
+        "gopd": "^1.0.1",
+        "safe-array-concat": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
-    "once": {
+    "node_modules/once": {
       "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "wrappy": "1"
       }
     },
-    "onecolor": {
+    "node_modules/onecolor": {
       "version": "2.5.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/onecolor/-/onecolor-2.5.0.tgz",
-      "integrity": "sha1-Ila2UdyAfBAfAK7b1JklxXpEMcE=",
-      "dev": true
-    },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
-    },
-    "os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-      "dev": true
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha1-hc36+uso6Gd/QW4odZK18/SepBA=",
+      "resolved": "https://registry.npmjs.org/onecolor/-/onecolor-2.5.0.tgz",
+      "integrity": "sha512-OdUvcyPnJ+o35vXb6RIY3fxJITm+EGcfFECanoOKnISTFG+Pl/I1n5TcbxH+KHC310+RopEG4Cccz+naDWAD2A==",
       "dev": true,
-      "requires": {
+      "engines": {
+        "node": ">=0.4.8"
+      }
+    },
+    "node_modules/os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
       }
     },
-    "p-finally": {
+    "node_modules/own-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-intrinsic": "^1.2.6",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-finally": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-      "dev": true
-    },
-    "p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha1-4drMvnjQ0TiMoYxk/qOOPlfjcGs=",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
       "dev": true,
-      "requires": {
-        "yocto-queue": "^0.1.0"
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
-    "p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha1-g8gxXGeFAF470CGDlBHJ4RDm2DQ=",
-      "dev": true,
-      "requires": {
-        "p-limit": "^3.0.2"
-      }
-    },
-    "package-json": {
+    "node_modules/package-json": {
       "version": "2.4.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/package-json/-/package-json-2.4.0.tgz",
-      "integrity": "sha1-DRW9Z9HLvduyyiIv8u24a8sxqLs=",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
+      "integrity": "sha512-PRg65iXMTt/uK8Rfh5zvzkUbfAPitF17YaCY+IbHsYgksiLvtzWWTUildHth3mVaZ7871OJ7gtP4LBRBlmAdXg==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "got": "^5.0.0",
         "registry-auth-token": "^3.0.1",
         "registry-url": "^3.0.3",
         "semver": "^5.1.0"
       },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
-          "dev": true
-        }
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "pako": {
+    "node_modules/pako": {
       "version": "1.0.11",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha1-bJWZ00DVTf05RjgCUqNXBaa5kr8=",
-      "dev": true
-    },
-    "parse-cache-control": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
-      "integrity": "sha1-juqz5U+laSD+Fro493+iGqzC104=",
-      "dev": true
-    },
-    "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true,
-      "requires": {
-        "error-ex": "^1.2.0"
-      }
+      "license": "(MIT AND Zlib)"
     },
-    "parseurl": {
-      "version": "1.3.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/parseurl/-/parseurl-1.3.3.tgz",
-      "integrity": "sha1-naGee+6NEt/wUT7Vt2lXeTvC6NQ=",
-      "dev": true
-    },
-    "path-exists": {
+    "node_modules/parse-json": {
       "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha1-UTvb4tO5XXdi6METfvoZXGxhtbM=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "error-ex": "^1.3.1",
+        "json-parse-better-errors": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "path-is-absolute": {
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "path-key": {
+    "node_modules/path-key": {
       "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "path-parse": {
+    "node_modules/path-parse": {
       "version": "1.0.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha1-+8EUtgykKzDZ2vWFjkvWi77bZzU=",
-      "dev": true
-    },
-    "path-type": {
-      "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha1-zvMdyOCho7sNEFwM2Xzzv0f0428=",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
-      "requires": {
+      "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha1-8fBh3o9qS/AiiS4tEoI0+5gwKXI=",
-      "dev": true
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
-    "pidtree": {
+    "node_modules/pidtree": {
       "version": "0.3.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/pidtree/-/pidtree-0.3.1.tgz",
-      "integrity": "sha1-7wmsLMBTPfHzJQzPLE02aw0SEUo=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz",
+      "integrity": "sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "pidtree": "bin/pidtree.js"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
     },
-    "pify": {
+    "node_modules/pify": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
-    "pinkie": {
+    "node_modules/pinkie": {
       "version": "2.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-      "dev": true
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "pinkie": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "pkginfo": {
+    "node_modules/pkginfo": {
       "version": "0.4.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/pkginfo/-/pkginfo-0.4.1.tgz",
-      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
-      "dev": true
-    },
-    "prepend-http": {
-      "version": "1.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/prepend-http/-/prepend-http-1.0.4.tgz",
-      "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
-      "dev": true
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha1-eCDZsWEgzFXKmud5JoCufbptf+I=",
-      "dev": true
-    },
-    "promise": {
-      "version": "8.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/promise/-/promise-8.1.0.tgz",
-      "integrity": "sha1-aXwlw9/nQ13Xn81Yw4oTWIjq8F4=",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
+      "integrity": "sha512-8xCNE/aT/EXKenuMDZ+xTVwkT8gsoHN2z/Q29l80u0ppGEXVvsKRzNMbtKhg8LS8k1tJLAHHylf6p4VFmP6XUQ==",
       "dev": true,
-      "requires": {
-        "asap": "~2.0.6"
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
-    "prompt": {
-      "version": "0.2.14",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/prompt/-/prompt-0.2.14.tgz",
-      "integrity": "sha1-V3VPZPVD/XsIRXB8gY7OYY8F/9w=",
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha512-PhmXi5XmoyKw1Un4E+opM2KcsJInDvKyuOumcjjw3waw86ZNjHwVUOOWLc4bCzLdcKNaWBH9e99sbWzDQsVaYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prompt": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/prompt/-/prompt-0.2.14.tgz",
+      "integrity": "sha512-jDK5yEbAakJmNm+260gZG1+PuzX3jT5Jy0VZAUGrrW9RQ1JEWEDEVNnhO70mL3+U5r6bSJo02xsE34wOS/LnrA==",
+      "dev": true,
+      "dependencies": {
         "pkginfo": "0.x.x",
         "read": "1.0.x",
         "revalidator": "0.1.x",
         "utile": "0.2.x",
         "winston": "0.8.x"
+      },
+      "engines": {
+        "node": ">= 0.6.6"
       }
     },
-    "pseudomap": {
+    "node_modules/pseudomap": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
-      "dev": true
-    },
-    "q": {
-      "version": "1.5.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=",
-      "dev": true
-    },
-    "qjobs": {
-      "version": "1.2.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/qjobs/-/qjobs-1.2.0.tgz",
-      "integrity": "sha1-xF6cYYAL0IfviNfiVkI73Unl0HE=",
-      "dev": true
-    },
-    "qs": {
-      "version": "6.7.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/qs/-/qs-6.7.0.tgz",
-      "integrity": "sha1-QdwaAV49WB8WIXdr4xr7KHapsbw=",
-      "dev": true
-    },
-    "quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha1-NmST5rPkKjpoheLpnRj4D7eoyTI=",
-      "dev": true
-    },
-    "range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha1-PPNwI9GZ4cJNGlW4SADC8+ZGgDE=",
-      "dev": true
-    },
-    "raw-body": {
-      "version": "2.4.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/raw-body/-/raw-body-2.4.0.tgz",
-      "integrity": "sha1-oc5vucm8NWylLoklarWQWeE9AzI=",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
       "dev": true,
-      "requires": {
-        "bytes": "3.1.0",
-        "http-errors": "1.7.2",
+      "license": "ISC"
+    },
+    "node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
+      "deprecated": "You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.\n\n(For a CapTP with native promises, see @endo/eventual-send and @endo/captp)",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0",
+        "teleport": ">=0.2.0"
+      }
+    },
+    "node_modules/qjobs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.2.0.tgz",
+      "integrity": "sha512-8YOJEHtxpySA3fFDyCRxA+UUV+fA+rTWnuWvylOK/NCjhY+b4ocCtmu8TtsWb+mYeU+GCHf/S66KZF/AsteKHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.9"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
-    "rc": {
+    "node_modules/rc": {
       "version": "1.2.8",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/rc/-/rc-1.2.8.tgz",
-      "integrity": "sha1-zZJL9SAKB1uDwYjNa54hG3/A0+0=",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
-      "requires": {
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
         "minimist": "^1.2.0",
         "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
       }
     },
-    "read": {
+    "node_modules/read": {
       "version": "1.0.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/read/-/read-1.0.7.tgz",
-      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+      "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
       "dev": true,
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "mute-stream": "~0.0.4"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
-    "read-all-stream": {
+    "node_modules/read-all-stream": {
       "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/read-all-stream/-/read-all-stream-3.1.0.tgz",
-      "integrity": "sha1-NcPhd/IHjveJ7kv6+kNzB06u9Po=",
+      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+      "integrity": "sha512-DI1drPHbmBcUDWrJ7ull/F2Qb8HkwBncVx8/RpKYFSIACYaVRQReISYPdZz/mt1y1+qMCOrfReTopERmaxtP6w==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "pinkie-promise": "^2.0.0",
         "readable-stream": "^2.0.0"
-      }
-    },
-    "read-pkg": {
-      "version": "6.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/read-pkg/-/read-pkg-6.0.0.tgz",
-      "integrity": "sha1-pnp9ahwrDDzWqi6lIfQMRYpKUEw=",
-      "dev": true,
-      "requires": {
-        "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^3.0.2",
-        "parse-json": "^5.2.0",
-        "type-fest": "^1.0.1"
       },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/read-pkg": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+      "integrity": "sha512-BLq/cCO9two+lBgiTYNqD6GdtK8s4NpaWrl6/rCO9w0TUS8oJl7cmToOZfRYllKTISY6nt1U7jQ53brmKqY6BA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "parse-json": {
-          "version": "5.2.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/parse-json/-/parse-json-5.2.0.tgz",
-          "integrity": "sha1-x2/Gbe5UIxyWKyK8yKcs8vmXU80=",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.0.0",
-            "error-ex": "^1.3.1",
-            "json-parse-even-better-errors": "^2.3.0",
-            "lines-and-columns": "^1.1.6"
-          }
-        }
+        "load-json-file": "^4.0.0",
+        "normalize-package-data": "^2.3.2",
+        "path-type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
-    "read-pkg-up": {
-      "version": "8.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
-      "integrity": "sha1-cvWVtl5mEQ9DsFLdmvTeaxBTRnA=",
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dev": true,
-      "requires": {
-        "find-up": "^5.0.0",
-        "read-pkg": "^6.0.0",
-        "type-fest": "^1.0.1"
-      }
-    },
-    "readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha1-Hsoc9xGu+BTAT2IlKjamL2yyO1c=",
-      "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
         "isarray": "~1.0.0",
@@ -3164,501 +4471,943 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "readdirp": {
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readdirp": {
       "version": "3.6.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha1-dKNwvYVxFuJFspzJc0DNQxoCpsc=",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
-    "rechoir": {
+    "node_modules/rechoir": {
       "version": "0.6.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "resolve": "^1.1.6"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
-    "redent": {
-      "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/redent/-/redent-4.0.0.tgz",
-      "integrity": "sha1-DAunyquyQlerO7ek/ZXdHVxWgfk=",
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
       "dev": true,
-      "requires": {
-        "indent-string": "^5.0.0",
-        "strip-indent": "^4.0.0"
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "regexp.prototype.flags": {
-      "version": "1.3.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
-      "integrity": "sha1-fvNSro0VnnWMDq3Kb4/LTu8HviY=",
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
       "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "registry-auth-token": {
+    "node_modules/registry-auth-token": {
       "version": "3.4.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
-      "integrity": "sha1-10RoFUM/XV7WQxzV3KIQSPZrOX4=",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+      "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "rc": "^1.1.6",
         "safe-buffer": "^5.0.1"
       }
     },
-    "registry-url": {
+    "node_modules/registry-url": {
       "version": "3.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/registry-url/-/registry-url-3.1.0.tgz",
-      "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha512-ZbgR5aZEdf4UKZVBPYIgaglBmSF2Hi94s2PcIHhRGFjKYu+chjJdYfHn4rt3hB6eCKLJ8giVIIfgMa1ehDfZKA==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "rc": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "remove-trailing-separator": {
+    "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
+      "dev": true,
+      "license": "ISC"
     },
-    "repeating": {
+    "node_modules/repeating": {
       "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/repeating/-/repeating-2.0.1.tgz",
-      "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+      "integrity": "sha512-ZqtSMuVybkISo2OWvqvm7iHSWngvdaW3IpsT9/uP8v4gMi591LY6h35wdOfvQdWCKFWZWm2Y1Opp4kV7vQKT6A==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "is-finite": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "require-directory": {
+    "node_modules/require-directory": {
       "version": "2.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "requires-port": {
+    "node_modules/requires-port": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/requires-port/-/requires-port-1.0.0.tgz",
-      "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
-    },
-    "resolve": {
-      "version": "1.20.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/resolve/-/resolve-1.20.0.tgz",
-      "integrity": "sha1-YpoBP7P3B1XW8LeTXMHCxTeLGXU=",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true,
-      "requires": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
+      "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "revalidator": {
+    "node_modules/revalidator": {
       "version": "0.1.8",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/revalidator/-/revalidator-0.1.8.tgz",
-      "integrity": "sha1-/s5hv6DBtSoga9axgZgYS91SOjs=",
-      "dev": true
-    },
-    "rfdc": {
-      "version": "1.3.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/rfdc/-/rfdc-1.3.0.tgz",
-      "integrity": "sha1-0LfEQasnINBdxM8m4ByJYx2doIs=",
-      "dev": true
-    },
-    "rimraf": {
-      "version": "2.7.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/rimraf/-/rimraf-2.7.1.tgz",
-      "integrity": "sha1-NXl/E6f9rcVmFCwp1PB8ytSD4+w=",
+      "resolved": "https://registry.npmjs.org/revalidator/-/revalidator-0.1.8.tgz",
+      "integrity": "sha512-xcBILK2pA9oh4SiinPEZfhP8HfrB/ha+a2fTMyl7Om2WjlDVrOQy99N2MXXlUHqGJz4qEu2duXxHJjDWuK/0xg==",
       "dev": true,
-      "requires": {
-        "glob": "^7.1.3"
+      "license": "Apache 2.0",
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
-    "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0=",
-      "dev": true
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo=",
-      "dev": true
-    },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
-      "dev": true
-    },
-    "semver": {
-      "version": "7.1.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/semver/-/semver-7.1.3.tgz",
-      "integrity": "sha1-5DRc5zBxxT8zZEXPwZ77HDEd8qY=",
-      "dev": true
-    },
-    "semver-diff": {
-      "version": "2.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/semver-diff/-/semver-diff-2.1.0.tgz",
-      "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
-      "requires": {
+      "license": "MIT"
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+      "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.3.tgz",
+      "integrity": "sha512-y/52Mcy7aw3gRm7IrcGDFx/bCk4AhRh2eI9luHOQM86nZsqwiRkkq2GekHXBBD+SmPidc8i2PqtYZl+pWJ8Oeg==",
+      "dev": true,
+      "license": "WTFPL OR ISC",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
+      "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/semver-diff": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
+      "integrity": "sha512-gL8F8L4ORwsS0+iQ34yCYv///jsOq0ZL7WP55d1HnJ32o7tyFYEFQZQA22mrLIacZdU6xecaBBZ+uEiffGNyXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "semver": "^5.0.3"
       },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha1-qVT5Ma66UI0we78Gnv8MAclhFvc=",
-          "dev": true
-        }
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "setprototypeof": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/setprototypeof/-/setprototypeof-1.1.1.tgz",
-      "integrity": "sha1-fpWsskqpL1iF4KvvW6ExMw1K5oM=",
-      "dev": true
-    },
-    "shebang-command": {
-      "version": "1.2.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
       "dev": true,
-      "requires": {
-        "shebang-regex": "^1.0.0"
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "shebang-regex": {
+    "node_modules/set-proto": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
-      "dev": true
-    },
-    "shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha1-qkDtrBcERbmkMeF7tiwLiBucQSM=",
-      "dev": true
-    },
-    "shelljs": {
-      "version": "0.5.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/shelljs/-/shelljs-0.5.3.tgz",
-      "integrity": "sha1-xUmCuZbHbvDB5rWfvcWCX1txMRM=",
-      "dev": true
-    },
-    "side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha1-785cj9wQTudRslxY1CkAEfpeos8=",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
       "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
-    "signal-exit": {
-      "version": "3.0.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/signal-exit/-/signal-exit-3.0.6.tgz",
-      "integrity": "sha1-JOYwxLDwP+pEaivSmeYrSmyo0K8=",
-      "dev": true
-    },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-      "dev": true
-    },
-    "socket.io": {
-      "version": "4.4.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/socket.io/-/socket.io-4.4.0.tgz",
-      "integrity": "sha1-gUCg2ywiI1+Iptzrhn5NXJvXBQc=",
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "dev": true,
-      "requires": {
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/shelljs": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
+      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      },
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/socket.io": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "accepts": "~1.3.4",
         "base64id": "~2.0.0",
+        "cors": "~2.8.5",
         "debug": "~4.3.2",
-        "engine.io": "~6.1.0",
-        "socket.io-adapter": "~2.3.3",
-        "socket.io-parser": "~4.0.4"
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
       },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha1-BCZuC3CpjURi5uKI44JZITMytmQ=",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-          "dev": true
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
         }
       }
     },
-    "socket.io-adapter": {
-      "version": "2.3.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/socket.io-adapter/-/socket.io-adapter-2.3.3.tgz",
-      "integrity": "sha1-TWER5NQun3ZG42W09XgmmCHxNIY=",
-      "dev": true
-    },
-    "socket.io-parser": {
-      "version": "4.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/socket.io-parser/-/socket.io-parser-4.0.4.tgz",
-      "integrity": "sha1-nqIbDWFQjRgZbvBKLGuatjD0wrA=",
+    "node_modules/socket.io-adapter/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
-      "requires": {
-        "@types/component-emitter": "^1.2.10",
-        "component-emitter": "~1.3.0",
+      "license": "MIT"
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.3.1"
       },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha1-BCZuC3CpjURi5uKI44JZITMytmQ=",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-          "dev": true
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
         }
       }
     },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-      "dev": true
-    },
-    "spdx-correct": {
-      "version": "3.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/spdx-correct/-/spdx-correct-3.1.1.tgz",
-      "integrity": "sha1-3s6BrJweZxPl99G28X1Gj6U9iak=",
+    "node_modules/socket.io-parser/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
-      "requires": {
+      "license": "MIT"
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
         "spdx-expression-parse": "^3.0.0",
         "spdx-license-ids": "^3.0.0"
       }
     },
-    "spdx-exceptions": {
-      "version": "2.3.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha1-PyjOGnegA3JoPq3kpDMYNSeiFj0=",
-      "dev": true
-    },
-    "spdx-expression-parse": {
-      "version": "3.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
-      "integrity": "sha1-z3D1BILu/cmOPOCmgz5KU87rpnk=",
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
       "dev": true,
-      "requires": {
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
       }
     },
-    "spdx-license-ids": {
-      "version": "3.0.11",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-      "integrity": "sha1-UMDYxAoU7Bv0Sbrmmg6kaFqdn5U=",
-      "dev": true
-    },
-    "stable": {
-      "version": "0.1.8",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/stable/-/stable-0.1.8.tgz",
-      "integrity": "sha1-g26zyDgv4pNv6vVEYxAXzn1Ho88=",
-      "dev": true
-    },
-    "stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
-      "dev": true
-    },
-    "statuses": {
-      "version": "1.5.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-      "dev": true
-    },
-    "streamroller": {
-      "version": "2.2.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/streamroller/-/streamroller-2.2.4.tgz",
-      "integrity": "sha1-wZjO1C25QIamGTYIGHzoCl8rDlM=",
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.22",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
+      "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
       "dev": true,
-      "requires": {
-        "date-format": "^2.1.0",
-        "debug": "^4.1.1",
+      "license": "CC0-1.0"
+    },
+    "node_modules/stable": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.8.tgz",
+      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==",
+      "deprecated": "Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/streamroller": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.1.5.tgz",
+      "integrity": "sha512-KFxaM7XT+irxvdqSP1LGLgNWbYN7ay5owZ3r/8t77p+EtSUAfUgtl7be3xtqtOmGUl9K9YPO2ca8133RlTjvKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "date-format": "^4.0.14",
+        "debug": "^4.3.4",
         "fs-extra": "^8.1.0"
       },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/streamroller/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "date-format": {
-          "version": "2.1.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/date-format/-/date-format-2.1.0.tgz",
-          "integrity": "sha1-MdW16iEc9f12TNOLr50DPffhJc8=",
-          "dev": true
-        },
-        "debug": {
-          "version": "4.3.3",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha1-BCZuC3CpjURi5uKI44JZITMytmQ=",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha1-0J0fNXtEP0kzgqjrPM0YOHKuYAk=",
-          "dev": true
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
         }
       }
     },
-    "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+    "node_modules/streamroller/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
-      "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      }
+      "license": "MIT"
     },
-    "string.prototype.padend": {
-      "version": "3.1.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/string.prototype.padend/-/string.prototype.padend-3.1.3.tgz",
-      "integrity": "sha1-mXpt4SySx8s03IogGmxT2b2IpfE=",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.19.1"
-      }
-    },
-    "string.prototype.trimend": {
-      "version": "1.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
-      "integrity": "sha1-51rpDClCxjUEaGwYsoe0oLGkX4A=",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      }
-    },
-    "string.prototype.trimstart": {
-      "version": "1.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
-      "integrity": "sha1-s2OZr0qymZtMnGSL16P7K7Jv7u0=",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      }
-    },
-    "string_decoder": {
+    "node_modules/string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
-    "strip-ansi": {
+    "node_modules/string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string.prototype.padend": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.1.6.tgz",
+      "integrity": "sha512-XZpspuSB7vJWhvJc9DLSlrXl1mcA2BdoY5jjnS135ydXqLoqhs96JjDtCkjJEQHvfqZIp9hBuBMgI589peyx9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+      "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-object-atoms": "^1.0.0",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+      "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.2",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "strip-bom": {
+    "node_modules/strip-bom": {
       "version": "3.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-      "dev": true
-    },
-    "strip-eof": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-      "dev": true
-    },
-    "strip-indent": {
-      "version": "4.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/strip-indent/-/strip-indent-4.0.0.tgz",
-      "integrity": "sha1-tBN5Qz3Qb16ugF4h1jHgfuZw2FM=",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
-      "requires": {
-        "min-indent": "^1.0.1"
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
-    "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
-    },
-    "subdirs": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/subdirs/-/subdirs-1.0.1.tgz",
-      "integrity": "sha1-1lJkeHR25Mr378VJj7dAxp9ibUg=",
+    "node_modules/strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/subdirs": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/subdirs/-/subdirs-1.0.1.tgz",
+      "integrity": "sha512-KSbUKpwQIRcb5Th+l4EzxEZYpCwV/g0pQ348EV7CIM5YEEgzz2L1KJD8FCeTckTiE/TKn2u09DCxpdAL6/iFbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "es6-promise": "^3.0.2"
       }
     },
-    "supports-color": {
+    "node_modules/supports-color": {
       "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-      "dev": true
-    },
-    "sync-request": {
-      "version": "6.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/sync-request/-/sync-request-6.1.0.tgz",
-      "integrity": "sha1-6WIXVlteULv/4XmGi6dVMvtZfmg=",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
       "dev": true,
-      "requires": {
-        "http-response-object": "^3.0.1",
-        "sync-rpc": "^1.2.1",
-        "then-request": "^6.0.0"
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
-    "sync-rpc": {
-      "version": "1.3.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/sync-rpc/-/sync-rpc-1.3.6.tgz",
-      "integrity": "sha1-suiyVQoSzLxx34ZEgQUp3raGZac=",
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
-      "requires": {
-        "get-port": "^3.1.0"
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "tar-stream": {
+    "node_modules/tar-stream": {
       "version": "1.6.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/tar-stream/-/tar-stream-1.6.2.tgz",
-      "integrity": "sha1-jqVdqzeXIlPZqa+Q/c1VmuQ1xVU=",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "bl": "^1.0.0",
         "buffer-alloc": "^1.2.0",
         "end-of-stream": "^1.0.0",
@@ -3666,14 +5415,18 @@
         "readable-stream": "^2.3.0",
         "to-buffer": "^1.1.1",
         "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
-    "tfx-cli": {
+    "node_modules/tfx-cli": {
       "version": "0.7.11",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/tfx-cli/-/tfx-cli-0.7.11.tgz",
-      "integrity": "sha1-Z3FQWxZ9MARDnFyQDMfm/GNZ720=",
+      "resolved": "https://registry.npmjs.org/tfx-cli/-/tfx-cli-0.7.11.tgz",
+      "integrity": "sha512-vzYDhmC8qwjo1vJKJ87U71LQN3Y59i/Uzl6aplyK2xTo1ojkzMmqVksJjNWxYoGPGCXD9PKkxCzBIUsFMvOE1Q==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "app-root-path": "1.0.0",
         "archiver": "2.0.3",
         "async": "^1.4.0",
@@ -3700,249 +5453,449 @@
         "winreg": "0.0.12",
         "xml2js": "^0.4.16"
       },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
-        "glob": {
-          "version": "7.1.2",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha1-sj5DWK+oogL+ehAK8fX4g/AgB+4=",
-          "dev": true
-        }
-      }
-    },
-    "then-request": {
-      "version": "6.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/then-request/-/then-request-6.0.2.tgz",
-      "integrity": "sha1-7Bjdi1ykOq7ly5L35MFjDpUNTww=",
-      "dev": true,
-      "requires": {
-        "@types/concat-stream": "^1.6.0",
-        "@types/form-data": "0.0.33",
-        "@types/node": "^8.0.0",
-        "@types/qs": "^6.2.31",
-        "caseless": "~0.12.0",
-        "concat-stream": "^1.6.0",
-        "form-data": "^2.2.0",
-        "http-basic": "^8.1.1",
-        "http-response-object": "^3.0.1",
-        "promise": "^8.0.0",
-        "qs": "^6.4.0"
+      "bin": {
+        "tfx": "_build/tfx-cli.js"
       },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/tfx-cli/node_modules/async": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tfx-cli/node_modules/glob": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
       "dependencies": {
-        "@types/node": {
-          "version": "8.10.66",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/@types/node/-/node-8.10.66.tgz",
-          "integrity": "sha1-3QNdQJ3zIqzIPf9ipgLxKleDu7M=",
-          "dev": true
-        }
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
       }
     },
-    "timed-out": {
-      "version": "3.1.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/timed-out/-/timed-out-3.1.3.tgz",
-      "integrity": "sha1-lYYL/MXHbCd/j4Mm/Q9bLiDrohc=",
-      "dev": true
-    },
-    "timers-ext": {
-      "version": "0.1.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/timers-ext/-/timers-ext-0.1.7.tgz",
-      "integrity": "sha1-b1ethXjgej+5+R2Th9ZWR1VeJcY=",
+    "node_modules/tfx-cli/node_modules/shelljs": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.5.3.tgz",
+      "integrity": "sha512-C2FisSSW8S6TIYHHiMHN0NqzdjWfTekdMpA2FJTbRWnQMLO1RRIXEB9eVZYOlofYmjZA7fY3ChoFu09MeI3wlQ==",
       "dev": true,
-      "requires": {
-        "es5-ext": "~0.10.46",
-        "next-tick": "1"
+      "license": "BSD*",
+      "bin": {
+        "shjs": "bin/shjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
-    "tinytim": {
-      "version": "0.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/tinytim/-/tinytim-0.1.1.tgz",
-      "integrity": "sha1-yWih5VWa2VUyJO92J7qzTjyu+Kg=",
-      "dev": true
-    },
-    "tmp": {
+    "node_modules/tfx-cli/node_modules/tmp": {
       "version": "0.0.26",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/tmp/-/tmp-0.0.26.tgz",
-      "integrity": "sha1-nvqCDOKhD4H4l5VVus4/FVJs4fI=",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.26.tgz",
+      "integrity": "sha512-XYEM7aFncfdEdU4/3jUG2edvFAryxtKbahJXTv8WK34MoOmexbbyNyneT3nY8yPVD3h0J1b5fL6kqlDoyuebQQ==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "os-tmpdir": "~1.0.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
-    "to-buffer": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha1-STvUj2LXxD/N7TE6A9ytsuEhOoA=",
-      "dev": true
+    "node_modules/timed-out": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
+      "integrity": "sha512-pqqJOi1rF5zNs/ps4vmbE4SFCrM4iR7LW+GHAsHqO/EumqbIWceioevYLM5xZRgQSH6gFgL9J/uB7EcJhQ9niQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "to-regex-range": {
+    "node_modules/timers-ext": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.8.tgz",
+      "integrity": "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "es5-ext": "^0.10.64",
+        "next-tick": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/tinytim": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/tinytim/-/tinytim-0.1.1.tgz",
+      "integrity": "sha512-NIpsp9lBIxPNzB++HnMmUd4byzJSVbbO4F+As1Gb1IG/YQT5QvmBDjpx8SpDS8fhGC+t+Qw8ldQgbcAIaU+2cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.2.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/to-buffer/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha1-FkjESq58jZiKMmAY7XL1tN0DkuQ=",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
-    "toidentifier": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha1-fhvjRw8ed5SLxD2Uo8j013UrpVM=",
-      "dev": true
-    },
-    "tracer": {
-      "version": "0.7.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/tracer/-/tracer-0.7.4.tgz",
-      "integrity": "sha1-d/oEN8+Ct2vNvNRLhHRHcuWeUlk=",
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tracer": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/tracer/-/tracer-0.7.4.tgz",
+      "integrity": "sha512-yG3Yb4ztlE1CZHNRWcBqjRIVSCXd8fx7HvL9gvlC37tpPrG3I5skNAY3mQApWeQiw0/3m83JWbfagwOAlmP/ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "colors": "1.0.3",
         "dateformat": "1.0.11",
         "tinytim": "0.1.1"
       },
-      "dependencies": {
-        "colors": {
-          "version": "1.0.3",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-          "dev": true
-        }
+      "engines": {
+        "node": ">= 0.10.0"
       }
     },
-    "trim-newlines": {
-      "version": "4.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/trim-newlines/-/trim-newlines-4.0.2.tgz",
-      "integrity": "sha1-1qqvag3xtLU20YOHmmuTlImAjHw=",
-      "dev": true
-    },
-    "tsconfig-glob": {
-      "version": "0.4.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/tsconfig-glob/-/tsconfig-glob-0.4.3.tgz",
-      "integrity": "sha1-M9z8WnbQjWV8YiR5HIwudXhOG8Q=",
+    "node_modules/tracer/node_modules/colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "dev": true,
+      "license": "WTFPL",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "node_modules/tsconfig-glob": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/tsconfig-glob/-/tsconfig-glob-0.4.3.tgz",
+      "integrity": "sha512-kJnDlTYHrkYDQpgfsS5sMXB/orsfCPPTZP9cE71q4bSXyI+3KfvpoLrWCUdFyl3fCiJX6hVfiDDcrozTwwT2vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "exit": "^0.1.2",
         "glob": "^7.0.3",
         "resolve": "^1.1.7",
         "stable": "^0.1.5"
+      },
+      "bin": {
+        "tsconfig": "cli"
       }
     },
-    "tunnel": {
+    "node_modules/tunnel": {
       "version": "0.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/tunnel/-/tunnel-0.0.4.tgz",
-      "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
-      "dev": true
-    },
-    "type": {
-      "version": "1.2.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/type/-/type-1.2.0.tgz",
-      "integrity": "sha1-hI3XaY2vo+VKbEeedZxLw/GIR6A=",
-      "dev": true
-    },
-    "type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha1-6fuBP+O/F0TsNZ1V0a/++nbxS+E=",
-      "dev": true
-    },
-    "type-is": {
-      "version": "1.6.18",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha1-TlUs0F3wlGfcvE73Od6J8s83wTE=",
+      "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
+      "integrity": "sha512-o9QYRJN5WgS8oCtqvwzzcfnzaTnDPr7HpUsQdSXscTyzXbjvl4wSHPTUKOKzEaDeQvOuyRtt3ui+ujM7x7TReQ==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
+      }
+    },
+    "node_modules/type": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+      "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
-    "typed-rest-client": {
-      "version": "1.2.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
-      "integrity": "sha1-cjCF0gPzjX0UcnHl7Tp1SI60SgI=",
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+      "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "is-typed-array": "^1.1.13",
+        "possible-typed-array-names": "^1.0.0",
+        "reflect.getprototypeof": "^1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-rest-client": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typed-rest-client/-/typed-rest-client-1.2.0.tgz",
+      "integrity": "sha512-FrUshzZ1yxH8YwGR29PWWnfksLEILbWJydU7zfIRkyH7kAEzB62uMAl2WY6EyolWpLpVHeJGgQm45/MaruaHpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "tunnel": "0.0.4",
         "underscore": "1.8.3"
       }
     },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-      "dev": true
-    },
-    "typescript": {
-      "version": "4.5.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/typescript/-/typescript-4.5.2.tgz",
-      "integrity": "sha1-isH7qfUiVv2wb7ieQSL6ajRsKZg=",
-      "dev": true
-    },
-    "ua-parser-js": {
-      "version": "0.7.31",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
-      "integrity": "sha1-ZJplaxkd/6tPIdXgU+J8oXy/9cY=",
-      "dev": true
-    },
-    "unbox-primitive": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
-      "integrity": "sha1-CF4hViXsMWJXTciFmr7nilmxRHE=",
+    "node_modules/typescript": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1",
-        "has-bigints": "^1.0.1",
-        "has-symbols": "^1.0.2",
-        "which-boxed-primitive": "^1.0.2"
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
-    "underscore": {
-      "version": "1.8.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/underscore/-/underscore-1.8.3.tgz",
-      "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-      "dev": true
-    },
-    "universalify": {
-      "version": "0.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha1-tkb2m+OULavOzJ1mOcgNwQXvqmY=",
-      "dev": true
-    },
-    "unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-      "dev": true
-    },
-    "unzip-response": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/unzip-response/-/unzip-response-1.0.2.tgz",
-      "integrity": "sha1-uYTwh3/AqJwsdzzB73tbIytbBv4=",
-      "dev": true
-    },
-    "update-notifier": {
-      "version": "1.0.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/update-notifier/-/update-notifier-1.0.3.tgz",
-      "integrity": "sha1-j5LFFUgr1oMbfJMBPnD4dVLHz1o=",
+    "node_modules/ua-parser-js": {
+      "version": "0.7.41",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.41.tgz",
+      "integrity": "sha512-O3oYyCMPYgNNHuO7Jjk3uacJWZF8loBgwrfd/5LE/HyZ3lUIOdniQ7DNXJcIgZbwioZxk0fLfI4EVnetdiX5jg==",
       "dev": true,
-      "requires": {
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "ua-parser-js": "script/cli.js"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/underscore": {
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+      "integrity": "sha512-5WsVTFcH1ut/kkhAaHf4PVgI8c7++GiVcpCGxPouI6ZVjsqPnSDf8h/8HtVqc0t4fzRXwnMK70EcZeAs3PIddg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/unzip-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+      "integrity": "sha512-pwCcjjhEcpW45JZIySExBHYv5Y9EeL2OIGEfrSKp2dMUFGFv4CpvZkwJbVge8OvGH2BNNtJBx67DuKuJhf+N5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/update-notifier": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-1.0.3.tgz",
+      "integrity": "sha512-iQSLFuxB2ZFAxXGN28DTxk/GNGlBmtqawvguYDtChAHI9Xjy0z7c7hpw6ywutK34SEDYTpLEsAM1ATMq5pcQsw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
         "boxen": "^0.6.0",
         "chalk": "^1.0.0",
         "configstore": "^2.0.0",
@@ -3951,42 +5904,71 @@
         "lazy-req": "^1.1.0",
         "semver-diff": "^2.0.0",
         "xdg-basedir": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "url-parse-lax": {
+    "node_modules/url-parse-lax": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
-      "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha512-BVA4lR5PIviy2PMseNd2jbFQ+jwSwQGdJejf5ctd1rEXt0Ypd7yanUK9+lYechVlN5VaTJGsu2U/3MDDu6KgBA==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "prepend-http": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "util-deprecate": {
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
-    },
-    "util.promisify": {
-      "version": "1.1.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/util.promisify/-/util.promisify-1.1.1.tgz",
-      "integrity": "sha1-d4MvV87SyUeBdBScrpuW6ZGM1Us=",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
+      "license": "MIT"
+    },
+    "node_modules/util.promisify": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/util.promisify/-/util.promisify-1.1.3.tgz",
+      "integrity": "sha512-GIEaZ6o86fj09Wtf0VfZ5XP7tmd4t3jM5aZCgmBi231D0DB1AEBa3Aa6MP48DMsAIi96WkpWLimIWVwOjbDMOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
         "for-each": "^0.3.3",
-        "has-symbols": "^1.0.1",
-        "object.getownpropertydescriptors": "^2.1.1"
+        "get-intrinsic": "^1.2.6",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "object.getownpropertydescriptors": "^2.1.8",
+        "safe-array-concat": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "utile": {
+    "node_modules/utile": {
       "version": "0.2.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/utile/-/utile-0.2.1.tgz",
-      "integrity": "sha1-kwyI6ZCY1iIINMNWy9mncFItkNc=",
+      "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
+      "integrity": "sha512-ltfvuCJNa/JFOhKBBiQ9qDyyFwLstoMMO1ru0Yg/Mcl8dp1Z3IBaL7n+5dHpyma+d3lCogkgBQnWKtGxzNyqhg==",
       "dev": true,
-      "requires": {
+      "dependencies": {
         "async": "~0.2.9",
         "deep-equal": "*",
         "i": "0.3.x",
@@ -3994,130 +5976,230 @@
         "ncp": "0.4.x",
         "rimraf": "2.x.x"
       },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true
-        }
+      "engines": {
+        "node": ">= 0.6.4"
       }
     },
-    "utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+    "node_modules/utile/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
       "dev": true
     },
-    "uuid": {
-      "version": "2.0.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/uuid/-/uuid-2.0.3.tgz",
-      "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
-      "dev": true
-    },
-    "validate-npm-package-license": {
-      "version": "3.0.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
-      "integrity": "sha1-/JH2uce6FchX9MssXe/uw51PQQo=",
+    "node_modules/utile/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
     },
-    "validator": {
+    "node_modules/validator": {
       "version": "3.43.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/validator/-/validator-3.43.0.tgz",
-      "integrity": "sha1-lkZLmS1BloM9l6GUv0Cxn/VLrgU=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/validator/-/validator-3.43.0.tgz",
+      "integrity": "sha512-H9RMa5elH0361QGFKeZiIWxN0YJDKL9rblzaXVFEKrKkL9hROcg/4f5rJ90SLTjai0IPmN18v9LkH//wwN93bA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
-    "vary": {
+    "node_modules/vary": {
       "version": "1.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
-    "void-elements": {
+    "node_modules/void-elements": {
       "version": "2.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/void-elements/-/void-elements-2.0.1.tgz",
-      "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+      "integrity": "sha512-qZKX4RnBzH2ugr8Lxa7x+0V6XD9Sb/ouARtiasEQCHB1EVU4NXtmHsDDrx1dO4ne5fc3J6EW05BP1Dl0z0iung==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
-    "walkdir": {
+    "node_modules/walkdir": {
       "version": "0.0.11",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/walkdir/-/walkdir-0.0.11.tgz",
-      "integrity": "sha1-oW0CXrkxvQO1LzCMrtD0D86+lTI=",
-      "dev": true
+      "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.11.tgz",
+      "integrity": "sha512-lMFYXGpf7eg+RInVL021ZbJJT4hqsvsBvq5sZBp874jfhs3IWlA7OPoG0ojQrYcXHuUSi+Nqp6qGN+pPGaMgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0"
+      }
     },
-    "which": {
+    "node_modules/which": {
       "version": "1.3.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/which/-/which-1.3.1.tgz",
-      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
-      "requires": {
+      "license": "ISC",
+      "dependencies": {
         "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
       }
     },
-    "which-boxed-primitive": {
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
       "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-      "integrity": "sha1-E3V7yJsgmwSf5dhkMOIc9AqJqOY=",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
       "dev": true,
-      "requires": {
-        "is-bigint": "^1.0.1",
-        "is-boolean-object": "^1.1.0",
-        "is-number-object": "^1.0.4",
-        "is-string": "^1.0.5",
-        "is-symbol": "^1.0.3"
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "which-collection": {
-      "version": "1.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/which-collection/-/which-collection-1.0.1.tgz",
-      "integrity": "sha1-cOq3Hru9Ku+vMvkXCC/GLNy3CQY=",
+    "node_modules/which-typed-array": {
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
       "dev": true,
-      "requires": {
-        "is-map": "^2.0.1",
-        "is-set": "^2.0.1",
-        "is-weakmap": "^2.0.1",
-        "is-weakset": "^2.0.1"
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "which-typed-array": {
-      "version": "1.1.7",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/which-typed-array/-/which-typed-array-1.1.7.tgz",
-      "integrity": "sha1-J2F5m5oi1LhmCzwbQKuqdzlpF5M=",
-      "dev": true,
-      "requires": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "es-abstract": "^1.18.5",
-        "foreach": "^2.0.5",
-        "has-tostringtag": "^1.0.0",
-        "is-typed-array": "^1.1.7"
-      }
-    },
-    "widest-line": {
+    "node_modules/widest-line": {
       "version": "1.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/widest-line/-/widest-line-1.0.0.tgz",
-      "integrity": "sha1-DAnIXCqUaD0Nfq+O4JfVZL8OEFw=",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-1.0.0.tgz",
+      "integrity": "sha512-r5vvGtqsHUHn98V0jURY4Ts86xJf6+SzK9rpWdV8/73nURB3WFPIHd67aOvPw2fSuunIyHjAUqiJ2TY0x4E5gw==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
         "string-width": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
-    "winreg": {
+    "node_modules/winreg": {
       "version": "0.0.12",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/winreg/-/winreg-0.0.12.tgz",
-      "integrity": "sha1-BxBVVLoanQiXklHRKUdb/64wBrc=",
-      "dev": true
-    },
-    "winston": {
-      "version": "0.8.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/winston/-/winston-0.8.3.tgz",
-      "integrity": "sha1-ZLar9M0Brcrv1QCTk7HY6L7BnbA=",
+      "resolved": "https://registry.npmjs.org/winreg/-/winreg-0.0.12.tgz",
+      "integrity": "sha512-typ/+JRmi7RqP1NanzFULK36vczznSNN8kWVA9vIqXyv8GhghUlwhGp1Xj3Nms1FsPcNnsQrJOR10N58/nQ9hQ==",
       "dev": true,
-      "requires": {
+      "license": "BSD"
+    },
+    "node_modules/winston": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
+      "integrity": "sha512-fPoamsHq8leJ62D1M9V/f15mjQ1UHe4+7j1wpAT3fqgA5JqhJkk4aIfPEjfMTI9x6ZTjaLOpMAjluLtmgO5b6g==",
+      "dev": true,
+      "dependencies": {
         "async": "0.2.x",
         "colors": "0.6.x",
         "cycle": "1.0.x",
@@ -4126,168 +6208,249 @@
         "pkginfo": "0.3.x",
         "stack-trace": "0.0.x"
       },
-      "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E=",
-          "dev": true
-        },
-        "colors": {
-          "version": "0.6.2",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/colors/-/colors-0.6.2.tgz",
-          "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w=",
-          "dev": true
-        },
-        "pkginfo": {
-          "version": "0.3.1",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/pkginfo/-/pkginfo-0.3.1.tgz",
-          "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE=",
-          "dev": true
-        }
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
-    "wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha1-Z+FFz/UQpqaYS98RUpEdadLrnkM=",
+    "node_modules/winston/node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha512-eAkdoKxU6/LkKDBzLpT+t6Ff5EtfSF4wx1WfJiPEEV7WNLnDaRXk0oVysiEPm262roaachGexwUv94WhSgN5TQ==",
+      "dev": true
+    },
+    "node_modules/winston/node_modules/colors": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+      "integrity": "sha512-OsSVtHK8Ir8r3+Fxw/b4jS1ZLPXkV6ZxDRJQzeD7qo0SqMXWrHDM71DgYzPMHY8SFJ0Ao+nNU2p1MmwdzKqPrw==",
       "dev": true,
-      "requires": {
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/winston/node_modules/pkginfo": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+      "integrity": "sha512-yO5feByMzAp96LtP58wvPKSbaKAi/1C4kV9XpTctr6EepnP6F33RBNOiVrdz9BrPA98U2BMFsTNHo44TWcbQ2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
       },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha1-7dgDYornHATIWuegkG7a00tkiTc=",
-          "dev": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha1-ctOmjVmMm9s68q0ehPIdiWq9TeM=",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha1-wqCah6y95pVD3m9j+jmVyCbFNqI=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        }
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
-    },
-    "write-file-atomic": {
-      "version": "1.3.4",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
-      "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+      "integrity": "sha512-SdrHoC/yVBPpV0Xq/mUZQIpW2sWXAShb/V4pomcJXh92RuaO+f3UTWItiR3Px+pLnV2PvC2/bfn5cwr5X6Vfxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
         "graceful-fs": "^4.1.11",
         "imurmurhash": "^0.1.4",
         "slide": "^1.1.5"
       }
     },
-    "ws": {
-      "version": "8.2.3",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ws/-/ws-8.2.3.tgz",
-      "integrity": "sha1-Y6VkVtsbBDZ9C3IaC4DK5ti+y7o=",
-      "dev": true
-    },
-    "xdg-basedir": {
-      "version": "2.0.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
-      "integrity": "sha1-7byQPMOF/ARSPZZqM1UEtVBNG9I=",
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
       "dev": true,
-      "requires": {
-        "os-homedir": "^1.0.0"
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
-    "xml2js": {
-      "version": "0.4.23",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/xml2js/-/xml2js-0.4.23.tgz",
-      "integrity": "sha1-oMaVFnUkIesqx1juTUzPWIQ+rGY=",
+    "node_modules/xdg-basedir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-2.0.0.tgz",
+      "integrity": "sha512-NF1pPn594TaRSUO/HARoB4jK8I+rWgcpVlpQCK6/6o5PHyLUt2CSiDrpUZbQ6rROck+W2EwF8mBJcTs+W98J9w==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "dependencies": {
+        "os-homedir": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
-    "xmlbuilder": {
+    "node_modules/xmlbuilder": {
       "version": "11.0.1",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
-      "integrity": "sha1-vpuuHIoEbnazESdyY0fQrXACvrM=",
-      "dev": true
-    },
-    "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
-      "dev": true
-    },
-    "y18n": {
-      "version": "5.0.8",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha1-f0k00PfKjFb5UxSTndzS3ZHOHVU=",
-      "dev": true
-    },
-    "yallist": {
-      "version": "2.1.2",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-      "dev": true
-    },
-    "yargs": {
-      "version": "16.2.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha1-HIK/D2tqZur85+8w43b0mhJHf2Y=",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
       "dev": true,
-      "requires": {
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "cliui": "^7.0.2",
         "escalade": "^3.1.1",
         "get-caller-file": "^2.0.5",
@@ -4296,63 +6459,82 @@
         "y18n": "^5.0.5",
         "yargs-parser": "^20.2.2"
       },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.1",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/ansi-regex/-/ansi-regex-5.0.1.tgz",
-          "integrity": "sha1-CCyyyJyf6GWaMRpTvWpNxTAdswQ=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "3.0.0",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha1-8Rb4Bk/pCz94RKOJl8C3UFEmnx0=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "4.2.3",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/string-width/-/string-width-4.2.3.tgz",
-          "integrity": "sha1-JpxxF9J7Ba0uU2gwqOyJXvnG0BA=",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "6.0.1",
-          "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/strip-ansi/-/strip-ansi-6.0.1.tgz",
-          "integrity": "sha1-nibGPTD1NEPpSJSVshBdN7Z6hdk=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.1"
-          }
-        }
+      "engines": {
+        "node": ">=10"
       }
     },
-    "yargs-parser": {
+    "node_modules/yargs-parser": {
       "version": "20.2.9",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha1-LrfcOwKJcY/ClfNidThFxBoMlO4=",
-      "dev": true
-    },
-    "yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha1-ApTrPe4FAo0x7hpfosVWpqrxChs=",
-      "dev": true
-    },
-    "zip-stream": {
-      "version": "1.2.0",
-      "resolved": "https://pkgs.dev.azure.com/blackbaud/_packaging/Blackbaud-npm/npm/registry/zip-stream/-/zip-stream-1.2.0.tgz",
-      "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
       "dev": true,
-      "requires": {
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
+      "integrity": "sha512-2olrDUuPM4NvRIgGPhvrp84f7/HmWR6RiQrgwFF2VctmnssFiogtYL3DcA8Vl2bsSmju79sVXe38TsII7JleUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
         "archiver-utils": "^1.3.0",
         "compress-commons": "^1.2.0",
         "lodash": "^4.8.0",
         "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -35,15 +35,15 @@
     "@types/jasmine": "^3.10.2",
     "@types/js-yaml": "^4.0.5",
     "@types/micromatch": "^4.0.2",
-    "@types/node": "^16.11.11",
+    "@types/node": "^20.3.1",
     "@types/parse-glob": "^3.0.29",
     "@types/q": "^1.5.5",
     "async": "^3.2.2",
-    "azure-pipelines-task-lib": "^3.1.10",
+    "azure-pipelines-task-lib": "^4.13.0",
     "gl-vsts-tasks-build-scripts": "^0.6.0",
     "karma": "^6.3.9",
     "npm-run-all": "^4.1.5",
-    "typescript": "^4.5.2"
+    "typescript": "5.1.6"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
This PR intends to fix the warning:

##[warning]Task 'Load JSON Variables' version 2 (LoadJsonVariables@2) is dependent on a Node version (10) that is end-of-life. Contact the extension owner for an updated version of the task. Task maintainers should review Node upgrade guidance: https://aka.ms/node-runner-guidance


I updated the task with Microsoft's recommendation from the link in the warning